### PR TITLE
feat(actions): Weather-related actions

### DIFF
--- a/Scenamatica/NMSBridge/NMSTypes/src/main/java/org/kunlab/scenamatica/nms/WrapperProvider.java
+++ b/Scenamatica/NMSBridge/NMSTypes/src/main/java/org/kunlab/scenamatica/nms/WrapperProvider.java
@@ -6,6 +6,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -16,6 +17,7 @@ import org.kunlab.scenamatica.nms.types.entity.NMSEntityHuman;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityPlayer;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
 import org.kunlab.scenamatica.nms.types.world.NMSWorldServer;
 
@@ -34,6 +36,8 @@ public interface WrapperProvider
     NMSEntityItem wrap(Item bukkitEntity);
 
     NMSEntityPlayer wrap(Player bukkitEntity);
+
+    NMSLightningStrike wrap(LightningStrike bukkitLightningStrike);
 
     // ==================[ ITEMS ]==================
 

--- a/Scenamatica/NMSBridge/NMSTypes/src/main/java/org/kunlab/scenamatica/nms/enums/entity/NMSLightningStrikeCause.java
+++ b/Scenamatica/NMSBridge/NMSTypes/src/main/java/org/kunlab/scenamatica/nms/enums/entity/NMSLightningStrikeCause.java
@@ -1,0 +1,49 @@
+package org.kunlab.scenamatica.nms.enums.entity;
+
+import org.bukkit.event.weather.LightningStrikeEvent;
+
+public enum NMSLightningStrikeCause
+{
+    COMMAND,
+    TRIDENT,
+    TRAP,
+    WEATHER,
+    UNKNOWN;
+
+    public static NMSLightningStrikeCause fromBukkit(LightningStrikeEvent.Cause cause)
+    {
+        if (cause == null)
+            return null;
+
+        switch (cause)
+        {
+            case COMMAND:
+                return COMMAND;
+            case TRIDENT:
+                return TRIDENT;
+            case TRAP:
+                return TRAP;
+            case WEATHER:
+                return WEATHER;
+            default:
+                return UNKNOWN;
+        }
+    }
+
+    public static LightningStrikeEvent.Cause toBukkit(NMSLightningStrikeCause cause)
+    {
+        switch (cause)
+        {
+            case COMMAND:
+                return LightningStrikeEvent.Cause.COMMAND;
+            case TRIDENT:
+                return LightningStrikeEvent.Cause.TRIDENT;
+            case TRAP:
+                return LightningStrikeEvent.Cause.TRAP;
+            case WEATHER:
+                return LightningStrikeEvent.Cause.WEATHER;
+            default:
+                return null;
+        }
+    }
+}

--- a/Scenamatica/NMSBridge/NMSTypes/src/main/java/org/kunlab/scenamatica/nms/types/entity/NMSLightningStrike.java
+++ b/Scenamatica/NMSBridge/NMSTypes/src/main/java/org/kunlab/scenamatica/nms/types/entity/NMSLightningStrike.java
@@ -1,0 +1,25 @@
+package org.kunlab.scenamatica.nms.types.entity;
+
+import org.bukkit.entity.LightningStrike;
+
+/**
+ * {@link LightningStrike} のラッパです。
+ */
+public interface NMSLightningStrike extends NMSEntity
+{
+    /**
+     * 雷が視覚的なものだけかどうかを取得します。
+     *
+     * @param visualOnly 視覚的なものだけかどうか
+     * @see LightningStrike#isEffect()
+     */
+    void setVisualOnly(boolean visualOnly);
+
+    /**
+     * ラップしている {@link LightningStrike} を取得します。
+     *
+     * @return {@link LightningStrike}
+     */
+    @Override
+    LightningStrike getBukkit();
+}

--- a/Scenamatica/NMSBridge/NMSTypes/src/main/java/org/kunlab/scenamatica/nms/types/world/NMSWorldServer.java
+++ b/Scenamatica/NMSBridge/NMSTypes/src/main/java/org/kunlab/scenamatica/nms/types/world/NMSWorldServer.java
@@ -1,11 +1,14 @@
 package org.kunlab.scenamatica.nms.types.world;
 
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LightningStrike;
 import org.jetbrains.annotations.NotNull;
 import org.kunlab.scenamatica.nms.NMSWrapped;
 import org.kunlab.scenamatica.nms.Versioned;
+import org.kunlab.scenamatica.nms.enums.entity.NMSLightningStrikeCause;
 
 /**
  * WorldServer の NMS による実装を提供します。
@@ -49,4 +52,23 @@ public interface NMSWorldServer extends NMSWrapped
      * @param param2 ブロック固有パラメータ２
      */
     void playBlockAction(Block block, int param1, int param2);
+
+    /**
+     * ワールドに落雷を発生させます。
+     *
+     * @param location 落雷の位置
+     * @param isEffect 落雷のエフェクトを表示するかどうか
+     * @param cause    落雷の原因
+     */
+    @Versioned(from = "1.14")
+    void strikeLightning(@NotNull Location location, boolean isEffect, @NotNull NMSLightningStrikeCause cause);
+
+    /**
+     * ワールドに落雷を発生させます。
+     *
+     * @param strike 落雷のエンティティ
+     * @param cause  落雷の原因
+     */
+    @Versioned(from = "1.14")
+    void strikeLightning(@NotNull LightningStrike strike, @NotNull NMSLightningStrikeCause cause);
 }

--- a/Scenamatica/NMSBridge/v1_13_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R1/WrapperProviderImpl.java
+++ b/Scenamatica/NMSBridge/v1_13_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R1/WrapperProviderImpl.java
@@ -6,6 +6,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -16,6 +17,7 @@ import org.kunlab.scenamatica.nms.impl.v1_13_R1.entity.NMSEntityImpl;
 import org.kunlab.scenamatica.nms.impl.v1_13_R1.entity.NMSEntityItemImpl;
 import org.kunlab.scenamatica.nms.impl.v1_13_R1.entity.NMSEntityLivingImpl;
 import org.kunlab.scenamatica.nms.impl.v1_13_R1.entity.NMSEntityPlayerImpl;
+import org.kunlab.scenamatica.nms.impl.v1_13_R1.entity.NMSLightningStrikeImpl;
 import org.kunlab.scenamatica.nms.impl.v1_13_R1.item.NMSItemStackImpl;
 import org.kunlab.scenamatica.nms.impl.v1_13_R1.world.NMSWorldServerImpl;
 import org.kunlab.scenamatica.nms.types.NMSMinecraftServer;
@@ -25,6 +27,7 @@ import org.kunlab.scenamatica.nms.types.entity.NMSEntityHuman;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityPlayer;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
 import org.kunlab.scenamatica.nms.types.world.NMSWorldServer;
 
@@ -58,6 +61,11 @@ public class WrapperProviderImpl implements WrapperProvider
     public static NMSEntityPlayer wrap$(Player bukkitEntity)
     {
         return new NMSEntityPlayerImpl(bukkitEntity);
+    }
+
+    public static NMSLightningStrike wrap$(LightningStrike bukkitLightningStrike)
+    {
+        return new NMSLightningStrikeImpl(bukkitLightningStrike);
     }
 
     public static NMSItemStack wrap$(ItemStack bukkitItemStack)
@@ -103,6 +111,12 @@ public class WrapperProviderImpl implements WrapperProvider
     public NMSEntityPlayer wrap(Player bukkitEntity)
     {
         return wrap$(bukkitEntity);
+    }
+
+    @Override
+    public NMSLightningStrike wrap(LightningStrike bukkitLightningStrike)
+    {
+        return wrap$(bukkitLightningStrike);
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_13_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R1/entity/NMSLightningStrikeImpl.java
+++ b/Scenamatica/NMSBridge/v1_13_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R1/entity/NMSLightningStrikeImpl.java
@@ -1,0 +1,31 @@
+package org.kunlab.scenamatica.nms.impl.v1_13_R1.entity;
+
+import net.minecraft.server.v1_13_R1.EntityLightning;
+import org.bukkit.craftbukkit.v1_13_R1.entity.CraftLightningStrike;
+import org.bukkit.entity.LightningStrike;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
+
+public class NMSLightningStrikeImpl extends NMSEntityImpl implements NMSLightningStrike
+{
+    private final LightningStrike bukkitLightningStrike;
+    private final EntityLightning nmsLightning;
+
+    public NMSLightningStrikeImpl(LightningStrike bukkitLightningStrike)
+    {
+        super(bukkitLightningStrike);
+        this.bukkitLightningStrike = bukkitLightningStrike;
+        this.nmsLightning = ((CraftLightningStrike) bukkitLightningStrike).getHandle();
+    }
+
+    @Override
+    public void setVisualOnly(boolean visualOnly)
+    {
+        this.nmsLightning.isEffect = visualOnly;
+    }
+
+    @Override
+    public LightningStrike getBukkit()
+    {
+        return this.bukkitLightningStrike;
+    }
+}

--- a/Scenamatica/NMSBridge/v1_13_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R1/item/NMSItemStackImpl.java
+++ b/Scenamatica/NMSBridge/v1_13_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R1/item/NMSItemStackImpl.java
@@ -3,7 +3,6 @@ package org.kunlab.scenamatica.nms.impl.v1_13_R1.item;
 import net.minecraft.server.v1_13_R1.EntityLiving;
 import net.minecraft.server.v1_13_R1.ItemStack;
 import org.bukkit.craftbukkit.v1_13_R1.inventory.CraftItemStack;
-import org.kunlab.scenamatica.nms.Versioned;
 import org.kunlab.scenamatica.nms.enums.entity.NMSItemSlot;
 import org.kunlab.scenamatica.nms.impl.v1_13_R1.NMSRegistryImpl;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
@@ -73,7 +72,7 @@ public class NMSItemStackImpl implements NMSItemStack
     }
 
     @Override
-    public <T extends NMSEntityLiving> @Versioned void damage(int damage, T owner, NMSItemSlot slot)
+    public <T extends NMSEntityLiving> void damage(int damage, T owner, NMSItemSlot slot)
     {
         this.nmsItemStack.damage(
                 damage,

--- a/Scenamatica/NMSBridge/v1_13_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R1/world/NMSWorldServerImpl.java
+++ b/Scenamatica/NMSBridge/v1_13_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R1/world/NMSWorldServerImpl.java
@@ -2,11 +2,14 @@ package org.kunlab.scenamatica.nms.impl.v1_13_R1.world;
 
 import net.minecraft.server.v1_13_R1.BlockPosition;
 import net.minecraft.server.v1_13_R1.WorldServer;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_13_R1.util.CraftMagicNumbers;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LightningStrike;
 import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.nms.enums.entity.NMSLightningStrikeCause;
 import org.kunlab.scenamatica.nms.exceptions.UnsupportedNMSOperationException;
 import org.kunlab.scenamatica.nms.types.world.NMSChunkProvider;
 import org.kunlab.scenamatica.nms.types.world.NMSPersistentEntitySectionManager;
@@ -59,6 +62,30 @@ public class NMSWorldServerImpl implements NMSWorldServer
                 NMSWorldServer.class,
                 "getEntityManager",
                 NMSPersistentEntitySectionManager.class
+        );
+    }
+
+    @Override
+    public void strikeLightning(@NotNull Location location, boolean isEffect, @NotNull NMSLightningStrikeCause cause)
+    {
+        throw UnsupportedNMSOperationException.of(
+                NMSWorldServer.class,
+                "strikeLightning",
+                void.class,
+                Location.class,
+                NMSLightningStrikeCause.class
+        );
+    }
+
+    @Override
+    public void strikeLightning(@NotNull LightningStrike entity, @NotNull NMSLightningStrikeCause cause)
+    {
+        throw UnsupportedNMSOperationException.of(
+                NMSWorldServer.class,
+                "strikeLightning",
+                void.class,
+                LightningStrike.class,
+                NMSLightningStrikeCause.class
         );
     }
 

--- a/Scenamatica/NMSBridge/v1_13_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R2/WrapperProviderImpl.java
+++ b/Scenamatica/NMSBridge/v1_13_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R2/WrapperProviderImpl.java
@@ -6,6 +6,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -16,6 +17,7 @@ import org.kunlab.scenamatica.nms.impl.v1_13_R2.entity.NMSEntityImpl;
 import org.kunlab.scenamatica.nms.impl.v1_13_R2.entity.NMSEntityItemImpl;
 import org.kunlab.scenamatica.nms.impl.v1_13_R2.entity.NMSEntityLivingImpl;
 import org.kunlab.scenamatica.nms.impl.v1_13_R2.entity.NMSEntityPlayerImpl;
+import org.kunlab.scenamatica.nms.impl.v1_13_R2.entity.NMSLightningStrikeImpl;
 import org.kunlab.scenamatica.nms.impl.v1_13_R2.item.NMSItemStackImpl;
 import org.kunlab.scenamatica.nms.impl.v1_13_R2.world.NMSWorldServerImpl;
 import org.kunlab.scenamatica.nms.types.NMSMinecraftServer;
@@ -25,6 +27,7 @@ import org.kunlab.scenamatica.nms.types.entity.NMSEntityHuman;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityPlayer;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
 import org.kunlab.scenamatica.nms.types.world.NMSWorldServer;
 
@@ -58,6 +61,11 @@ public class WrapperProviderImpl implements WrapperProvider
     public static NMSEntityPlayer wrap$(Player bukkitEntity)
     {
         return new NMSEntityPlayerImpl(bukkitEntity);
+    }
+
+    public static NMSLightningStrike wrap$(LightningStrike bukkitLightningStrike)
+    {
+        return new NMSLightningStrikeImpl(bukkitLightningStrike);
     }
 
     public static NMSItemStack wrap$(ItemStack bukkitItemStack)
@@ -103,6 +111,12 @@ public class WrapperProviderImpl implements WrapperProvider
     public NMSEntityPlayer wrap(Player bukkitEntity)
     {
         return wrap$(bukkitEntity);
+    }
+
+    @Override
+    public NMSLightningStrike wrap(LightningStrike bukkitLightningStrike)
+    {
+        return wrap$(bukkitLightningStrike);
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_13_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R2/entity/NMSLightningStrikeImpl.java
+++ b/Scenamatica/NMSBridge/v1_13_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R2/entity/NMSLightningStrikeImpl.java
@@ -1,0 +1,31 @@
+package org.kunlab.scenamatica.nms.impl.v1_13_R2.entity;
+
+import net.minecraft.server.v1_13_R2.EntityLightning;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftLightningStrike;
+import org.bukkit.entity.LightningStrike;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
+
+public class NMSLightningStrikeImpl extends NMSEntityImpl implements NMSLightningStrike
+{
+    private final LightningStrike bukkitLightningStrike;
+    private final EntityLightning nmsLightning;
+
+    public NMSLightningStrikeImpl(LightningStrike bukkitLightningStrike)
+    {
+        super(bukkitLightningStrike);
+        this.bukkitLightningStrike = bukkitLightningStrike;
+        this.nmsLightning = ((CraftLightningStrike) bukkitLightningStrike).getHandle();
+    }
+
+    @Override
+    public void setVisualOnly(boolean visualOnly)
+    {
+        this.nmsLightning.isEffect = visualOnly;
+    }
+
+    @Override
+    public LightningStrike getBukkit()
+    {
+        return this.bukkitLightningStrike;
+    }
+}

--- a/Scenamatica/NMSBridge/v1_13_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R2/item/NMSItemStackImpl.java
+++ b/Scenamatica/NMSBridge/v1_13_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R2/item/NMSItemStackImpl.java
@@ -3,7 +3,6 @@ package org.kunlab.scenamatica.nms.impl.v1_13_R2.item;
 import net.minecraft.server.v1_13_R2.EntityLiving;
 import net.minecraft.server.v1_13_R2.ItemStack;
 import org.bukkit.craftbukkit.v1_13_R2.inventory.CraftItemStack;
-import org.kunlab.scenamatica.nms.Versioned;
 import org.kunlab.scenamatica.nms.enums.entity.NMSItemSlot;
 import org.kunlab.scenamatica.nms.impl.v1_13_R2.NMSRegistryImpl;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
@@ -73,7 +72,7 @@ public class NMSItemStackImpl implements NMSItemStack
     }
 
     @Override
-    public <T extends NMSEntityLiving> @Versioned void damage(int damage, T owner, NMSItemSlot slot)
+    public <T extends NMSEntityLiving> void damage(int damage, T owner, NMSItemSlot slot)
     {
         this.nmsItemStack.damage(
                 damage,

--- a/Scenamatica/NMSBridge/v1_13_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R2/world/NMSWorldServerImpl.java
+++ b/Scenamatica/NMSBridge/v1_13_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R2/world/NMSWorldServerImpl.java
@@ -1,12 +1,16 @@
 package org.kunlab.scenamatica.nms.impl.v1_13_R2.world;
 
+import net.minecraft.server.v1_13_R2.EntityLightning;
 import net.minecraft.server.v1_13_R2.BlockPosition;
 import net.minecraft.server.v1_13_R2.WorldServer;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_13_R2.util.CraftMagicNumbers;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LightningStrike;
 import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.nms.enums.entity.NMSLightningStrikeCause;
 import org.kunlab.scenamatica.nms.exceptions.UnsupportedNMSOperationException;
 import org.kunlab.scenamatica.nms.types.world.NMSChunkProvider;
 import org.kunlab.scenamatica.nms.types.world.NMSPersistentEntitySectionManager;
@@ -61,6 +65,21 @@ public class NMSWorldServerImpl implements NMSWorldServer
                 "getEntityManager",
                 NMSPersistentEntitySectionManager.class
         );
+    }
+
+    @Override
+    public void strikeLightning(@NotNull Location location, boolean isEffect, @NotNull NMSLightningStrikeCause cause)
+    {
+        EntityLightning nmsEntity = new EntityLightning(this.nmsWorld, location.getX(), location.getY(), location.getZ(), false);
+        nmsEntity.isEffect = isEffect;
+        this.nmsWorld.strikeLightning(nmsEntity);
+    }
+
+    @Override
+    public void strikeLightning(@NotNull LightningStrike entity, @NotNull NMSLightningStrikeCause cause)
+    {
+        net.minecraft.server.v1_13_R2.Entity nmsEntity = ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity) entity).getHandle();
+        this.nmsWorld.strikeLightning(nmsEntity, NMSLightningStrikeCause.toBukkit(cause));
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_14_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_14_R1/WrapperProviderImpl.java
+++ b/Scenamatica/NMSBridge/v1_14_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_14_R1/WrapperProviderImpl.java
@@ -6,6 +6,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -16,6 +17,7 @@ import org.kunlab.scenamatica.nms.impl.v1_14_R1.entity.NMSEntityImpl;
 import org.kunlab.scenamatica.nms.impl.v1_14_R1.entity.NMSEntityItemImpl;
 import org.kunlab.scenamatica.nms.impl.v1_14_R1.entity.NMSEntityLivingImpl;
 import org.kunlab.scenamatica.nms.impl.v1_14_R1.entity.NMSEntityPlayerImpl;
+import org.kunlab.scenamatica.nms.impl.v1_14_R1.entity.NMSLightningStrikeImpl;
 import org.kunlab.scenamatica.nms.impl.v1_14_R1.item.NMSItemStackImpl;
 import org.kunlab.scenamatica.nms.impl.v1_14_R1.world.NMSWorldServerImpl;
 import org.kunlab.scenamatica.nms.types.NMSMinecraftServer;
@@ -25,6 +27,7 @@ import org.kunlab.scenamatica.nms.types.entity.NMSEntityHuman;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityPlayer;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
 import org.kunlab.scenamatica.nms.types.world.NMSWorldServer;
 
@@ -58,6 +61,11 @@ public class WrapperProviderImpl implements WrapperProvider
     public static NMSEntityPlayer wrap$(Player bukkitEntity)
     {
         return new NMSEntityPlayerImpl(bukkitEntity);
+    }
+
+    public static NMSLightningStrike wrap$(LightningStrike bukkitLightningStrike)
+    {
+        return new NMSLightningStrikeImpl(bukkitLightningStrike);
     }
 
     public static NMSItemStack wrap$(ItemStack bukkitItemStack)
@@ -103,6 +111,12 @@ public class WrapperProviderImpl implements WrapperProvider
     public NMSEntityPlayer wrap(Player bukkitEntity)
     {
         return wrap$(bukkitEntity);
+    }
+
+    @Override
+    public NMSLightningStrike wrap(LightningStrike bukkitLightningStrike)
+    {
+        return wrap$(bukkitLightningStrike);
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_14_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_14_R1/entity/NMSLightningStrikeImpl.java
+++ b/Scenamatica/NMSBridge/v1_14_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_14_R1/entity/NMSLightningStrikeImpl.java
@@ -1,0 +1,31 @@
+package org.kunlab.scenamatica.nms.impl.v1_14_R1.entity;
+
+import net.minecraft.server.v1_14_R1.EntityLightning;
+import org.bukkit.craftbukkit.v1_14_R1.entity.CraftLightningStrike;
+import org.bukkit.entity.LightningStrike;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
+
+public class NMSLightningStrikeImpl extends NMSEntityImpl implements NMSLightningStrike
+{
+    private final LightningStrike bukkitLightningStrike;
+    private final EntityLightning nmsLightning;
+
+    public NMSLightningStrikeImpl(LightningStrike bukkitLightningStrike)
+    {
+        super(bukkitLightningStrike);
+        this.bukkitLightningStrike = bukkitLightningStrike;
+        this.nmsLightning = ((CraftLightningStrike) bukkitLightningStrike).getHandle();
+    }
+
+    @Override
+    public void setVisualOnly(boolean visualOnly)
+    {
+        this.nmsLightning.isEffect = visualOnly;
+    }
+
+    @Override
+    public LightningStrike getBukkit()
+    {
+        return this.bukkitLightningStrike;
+    }
+}

--- a/Scenamatica/NMSBridge/v1_14_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_14_R1/item/NMSItemStackImpl.java
+++ b/Scenamatica/NMSBridge/v1_14_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_14_R1/item/NMSItemStackImpl.java
@@ -3,7 +3,6 @@ package org.kunlab.scenamatica.nms.impl.v1_14_R1.item;
 import net.minecraft.server.v1_14_R1.EntityLiving;
 import net.minecraft.server.v1_14_R1.ItemStack;
 import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftItemStack;
-import org.kunlab.scenamatica.nms.Versioned;
 import org.kunlab.scenamatica.nms.enums.entity.NMSItemSlot;
 import org.kunlab.scenamatica.nms.impl.v1_14_R1.NMSRegistryImpl;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
@@ -73,7 +72,7 @@ public class NMSItemStackImpl implements NMSItemStack
     }
 
     @Override
-    public <T extends NMSEntityLiving> @Versioned void damage(int damage, T owner, NMSItemSlot slot)
+    public <T extends NMSEntityLiving> void damage(int damage, T owner, NMSItemSlot slot)
     {
         this.nmsItemStack.damage(
                 damage,

--- a/Scenamatica/NMSBridge/v1_14_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_14_R1/world/NMSWorldServerImpl.java
+++ b/Scenamatica/NMSBridge/v1_14_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_14_R1/world/NMSWorldServerImpl.java
@@ -1,12 +1,16 @@
 package org.kunlab.scenamatica.nms.impl.v1_14_R1.world;
 
+import net.minecraft.server.v1_14_R1.EntityLightning;
 import net.minecraft.server.v1_14_R1.BlockPosition;
 import net.minecraft.server.v1_14_R1.WorldServer;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_14_R1.util.CraftMagicNumbers;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LightningStrike;
 import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.nms.enums.entity.NMSLightningStrikeCause;
 import org.kunlab.scenamatica.nms.exceptions.UnsupportedNMSOperationException;
 import org.kunlab.scenamatica.nms.types.world.NMSChunkProvider;
 import org.kunlab.scenamatica.nms.types.world.NMSPersistentEntitySectionManager;
@@ -61,6 +65,21 @@ public class NMSWorldServerImpl implements NMSWorldServer
                 "getEntityManager",
                 NMSPersistentEntitySectionManager.class
         );
+    }
+
+    @Override
+    public void strikeLightning(@NotNull Location location, boolean isEffect, @NotNull NMSLightningStrikeCause cause)
+    {
+        EntityLightning nmsEntity = new EntityLightning(this.nmsWorld, location.getX(), location.getY(), location.getZ(), false);
+        nmsEntity.isEffect = isEffect;
+        this.nmsWorld.strikeLightning(nmsEntity);
+    }
+
+    @Override
+    public void strikeLightning(@NotNull LightningStrike strike, @NotNull NMSLightningStrikeCause cause)
+    {
+        EntityLightning nmsEntity = ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftLightningStrike) strike).getHandle();
+        this.nmsWorld.strikeLightning(nmsEntity, NMSLightningStrikeCause.toBukkit(cause));
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_15_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_15_R1/WrapperProviderImpl.java
+++ b/Scenamatica/NMSBridge/v1_15_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_15_R1/WrapperProviderImpl.java
@@ -6,6 +6,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -16,6 +17,7 @@ import org.kunlab.scenamatica.nms.impl.v1_15_R1.entity.NMSEntityImpl;
 import org.kunlab.scenamatica.nms.impl.v1_15_R1.entity.NMSEntityItemImpl;
 import org.kunlab.scenamatica.nms.impl.v1_15_R1.entity.NMSEntityLivingImpl;
 import org.kunlab.scenamatica.nms.impl.v1_15_R1.entity.NMSEntityPlayerImpl;
+import org.kunlab.scenamatica.nms.impl.v1_15_R1.entity.NMSLightningStrikeImpl;
 import org.kunlab.scenamatica.nms.impl.v1_15_R1.item.NMSItemStackImpl;
 import org.kunlab.scenamatica.nms.impl.v1_15_R1.world.NMSWorldServerImpl;
 import org.kunlab.scenamatica.nms.types.NMSMinecraftServer;
@@ -25,6 +27,7 @@ import org.kunlab.scenamatica.nms.types.entity.NMSEntityHuman;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityPlayer;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
 import org.kunlab.scenamatica.nms.types.world.NMSWorldServer;
 
@@ -58,6 +61,11 @@ public class WrapperProviderImpl implements WrapperProvider
     public static NMSEntityPlayer wrap$(Player bukkitEntity)
     {
         return new NMSEntityPlayerImpl(bukkitEntity);
+    }
+
+    public static NMSLightningStrike wrap$(LightningStrike bukkitLightningStrike)
+    {
+        return new NMSLightningStrikeImpl(bukkitLightningStrike);
     }
 
     public static NMSItemStack wrap$(ItemStack bukkitItemStack)
@@ -103,6 +111,12 @@ public class WrapperProviderImpl implements WrapperProvider
     public NMSEntityPlayer wrap(Player bukkitEntity)
     {
         return wrap$(bukkitEntity);
+    }
+
+    @Override
+    public NMSLightningStrike wrap(LightningStrike bukkitLightningStrike)
+    {
+        return wrap$(bukkitLightningStrike);
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_15_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_15_R1/entity/NMSLightningStrikeImpl.java
+++ b/Scenamatica/NMSBridge/v1_15_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_15_R1/entity/NMSLightningStrikeImpl.java
@@ -1,0 +1,31 @@
+package org.kunlab.scenamatica.nms.impl.v1_15_R1.entity;
+
+import net.minecraft.server.v1_15_R1.EntityLightning;
+import org.bukkit.craftbukkit.v1_15_R1.entity.CraftLightningStrike;
+import org.bukkit.entity.LightningStrike;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
+
+public class NMSLightningStrikeImpl extends NMSEntityImpl implements NMSLightningStrike
+{
+    private final LightningStrike bukkitLightningStrike;
+    private final EntityLightning nmsLightning;
+
+    public NMSLightningStrikeImpl(LightningStrike bukkitLightningStrike)
+    {
+        super(bukkitLightningStrike);
+        this.bukkitLightningStrike = bukkitLightningStrike;
+        this.nmsLightning = ((CraftLightningStrike) bukkitLightningStrike).getHandle();
+    }
+
+    @Override
+    public void setVisualOnly(boolean visualOnly)
+    {
+        this.nmsLightning.isEffect = visualOnly;
+    }
+
+    @Override
+    public LightningStrike getBukkit()
+    {
+        return this.bukkitLightningStrike;
+    }
+}

--- a/Scenamatica/NMSBridge/v1_15_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_15_R1/item/NMSItemStackImpl.java
+++ b/Scenamatica/NMSBridge/v1_15_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_15_R1/item/NMSItemStackImpl.java
@@ -3,7 +3,6 @@ package org.kunlab.scenamatica.nms.impl.v1_15_R1.item;
 import net.minecraft.server.v1_15_R1.EntityLiving;
 import net.minecraft.server.v1_15_R1.ItemStack;
 import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftItemStack;
-import org.kunlab.scenamatica.nms.Versioned;
 import org.kunlab.scenamatica.nms.enums.entity.NMSItemSlot;
 import org.kunlab.scenamatica.nms.impl.v1_15_R1.NMSRegistryImpl;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
@@ -73,7 +72,7 @@ public class NMSItemStackImpl implements NMSItemStack
     }
 
     @Override
-    public <T extends NMSEntityLiving> @Versioned void damage(int damage, T owner, NMSItemSlot slot)
+    public <T extends NMSEntityLiving> void damage(int damage, T owner, NMSItemSlot slot)
     {
         this.nmsItemStack.damage(
                 damage,

--- a/Scenamatica/NMSBridge/v1_15_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_15_R1/world/NMSWorldServerImpl.java
+++ b/Scenamatica/NMSBridge/v1_15_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_15_R1/world/NMSWorldServerImpl.java
@@ -1,12 +1,16 @@
 package org.kunlab.scenamatica.nms.impl.v1_15_R1.world;
 
+import net.minecraft.server.v1_15_R1.EntityLightning;
 import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.WorldServer;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_15_R1.util.CraftMagicNumbers;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LightningStrike;
 import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.nms.enums.entity.NMSLightningStrikeCause;
 import org.kunlab.scenamatica.nms.exceptions.UnsupportedNMSOperationException;
 import org.kunlab.scenamatica.nms.types.world.NMSChunkProvider;
 import org.kunlab.scenamatica.nms.types.world.NMSPersistentEntitySectionManager;
@@ -60,6 +64,21 @@ public class NMSWorldServerImpl implements NMSWorldServer
                 "getEntityManager",
                 NMSPersistentEntitySectionManager.class
         );
+    }
+
+    @Override
+    public void strikeLightning(@NotNull Location location, boolean isEffect, @NotNull NMSLightningStrikeCause cause)
+    {
+        EntityLightning nmsEntity = new EntityLightning(this.nmsWorld, location.getX(), location.getY(), location.getZ(), false);
+        nmsEntity.isEffect = isEffect;
+        this.nmsWorld.strikeLightning(nmsEntity);
+    }
+
+    @Override
+    public void strikeLightning(@NotNull LightningStrike strike, @NotNull NMSLightningStrikeCause cause)
+    {
+        EntityLightning lightning = ((org.bukkit.craftbukkit.v1_15_R1.entity.CraftLightningStrike) strike).getHandle();
+        this.nmsWorld.strikeLightning(lightning, NMSLightningStrikeCause.toBukkit(cause));
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_16_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R1/WrapperProviderImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R1/WrapperProviderImpl.java
@@ -6,6 +6,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -16,6 +17,7 @@ import org.kunlab.scenamatica.nms.impl.v1_16_R1.entity.NMSEntityImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R1.entity.NMSEntityItemImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R1.entity.NMSEntityLivingImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R1.entity.NMSEntityPlayerImpl;
+import org.kunlab.scenamatica.nms.impl.v1_16_R1.entity.NMSLightningStrikeImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R1.item.NMSItemStackImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R1.world.NMSWorldServerImpl;
 import org.kunlab.scenamatica.nms.types.NMSMinecraftServer;
@@ -25,6 +27,7 @@ import org.kunlab.scenamatica.nms.types.entity.NMSEntityHuman;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityPlayer;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
 import org.kunlab.scenamatica.nms.types.world.NMSWorldServer;
 
@@ -58,6 +61,11 @@ public class WrapperProviderImpl implements WrapperProvider
     public static NMSEntityPlayer wrap$(Player bukkitEntity)
     {
         return new NMSEntityPlayerImpl(bukkitEntity);
+    }
+
+    public static NMSLightningStrike wrap$(LightningStrike bukkitLightningStrike)
+    {
+        return new NMSLightningStrikeImpl(bukkitLightningStrike);
     }
 
     public static NMSItemStack wrap$(ItemStack bukkitItemStack)
@@ -103,6 +111,12 @@ public class WrapperProviderImpl implements WrapperProvider
     public NMSEntityPlayer wrap(Player bukkitEntity)
     {
         return wrap$(bukkitEntity);
+    }
+
+    @Override
+    public NMSLightningStrike wrap(LightningStrike bukkitLightningStrike)
+    {
+        return wrap$(bukkitLightningStrike);
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_16_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R1/entity/NMSLightningStrikeImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R1/entity/NMSLightningStrikeImpl.java
@@ -1,0 +1,31 @@
+package org.kunlab.scenamatica.nms.impl.v1_16_R1.entity;
+
+import net.minecraft.server.v1_16_R1.EntityLightning;
+import org.bukkit.craftbukkit.v1_16_R1.entity.CraftLightningStrike;
+import org.bukkit.entity.LightningStrike;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
+
+public class NMSLightningStrikeImpl extends NMSEntityImpl implements NMSLightningStrike
+{
+    private final LightningStrike bukkitLightningStrike;
+    private final EntityLightning nmsLightning;
+
+    public NMSLightningStrikeImpl(LightningStrike bukkitLightningStrike)
+    {
+        super(bukkitLightningStrike);
+        this.bukkitLightningStrike = bukkitLightningStrike;
+        this.nmsLightning = ((CraftLightningStrike) bukkitLightningStrike).getHandle();
+    }
+
+    @Override
+    public void setVisualOnly(boolean visualOnly)
+    {
+        this.nmsLightning.isEffect = visualOnly;
+    }
+
+    @Override
+    public LightningStrike getBukkit()
+    {
+        return this.bukkitLightningStrike;
+    }
+}

--- a/Scenamatica/NMSBridge/v1_16_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R1/item/NMSItemStackImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R1/item/NMSItemStackImpl.java
@@ -3,7 +3,6 @@ package org.kunlab.scenamatica.nms.impl.v1_16_R1.item;
 import net.minecraft.server.v1_16_R1.EntityLiving;
 import net.minecraft.server.v1_16_R1.ItemStack;
 import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftItemStack;
-import org.kunlab.scenamatica.nms.Versioned;
 import org.kunlab.scenamatica.nms.enums.entity.NMSItemSlot;
 import org.kunlab.scenamatica.nms.impl.v1_16_R1.NMSRegistryImpl;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
@@ -73,7 +72,7 @@ public class NMSItemStackImpl implements NMSItemStack
     }
 
     @Override
-    public <T extends NMSEntityLiving> @Versioned void damage(int damage, T owner, NMSItemSlot slot)
+    public <T extends NMSEntityLiving> void damage(int damage, T owner, NMSItemSlot slot)
     {
         this.nmsItemStack.damage(
                 damage,

--- a/Scenamatica/NMSBridge/v1_16_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R1/world/NMSWorldServerImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R1/world/NMSWorldServerImpl.java
@@ -1,12 +1,17 @@
 package org.kunlab.scenamatica.nms.impl.v1_16_R1.world;
 
 import net.minecraft.server.v1_16_R1.BlockPosition;
+import net.minecraft.server.v1_16_R1.EntityLightning;
+import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.WorldServer;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_16_R1.util.CraftMagicNumbers;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LightningStrike;
 import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.nms.enums.entity.NMSLightningStrikeCause;
 import org.kunlab.scenamatica.nms.exceptions.UnsupportedNMSOperationException;
 import org.kunlab.scenamatica.nms.types.world.NMSChunkProvider;
 import org.kunlab.scenamatica.nms.types.world.NMSPersistentEntitySectionManager;
@@ -60,6 +65,22 @@ public class NMSWorldServerImpl implements NMSWorldServer
                 "getEntityManager",
                 NMSPersistentEntitySectionManager.class
         );
+    }
+
+    @Override
+    public void strikeLightning(@NotNull Location location, boolean isEffect, @NotNull NMSLightningStrikeCause cause)
+    {
+        EntityLightning nmsEntity = new EntityLightning(EntityTypes.LIGHTNING_BOLT, this.nmsWorld);
+        nmsEntity.isEffect = isEffect;
+        nmsEntity.setPosition(location.getX(), location.getY(), location.getZ());
+        this.nmsWorld.strikeLightning(nmsEntity);
+    }
+
+    @Override
+    public void strikeLightning(@NotNull LightningStrike strike, @NotNull NMSLightningStrikeCause cause)
+    {
+        EntityLightning lightning = ((org.bukkit.craftbukkit.v1_16_R1.entity.CraftLightningStrike) strike).getHandle();
+        this.nmsWorld.strikeLightning(lightning, NMSLightningStrikeCause.toBukkit(cause));
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_16_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R2/WrapperProviderImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R2/WrapperProviderImpl.java
@@ -6,6 +6,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -16,6 +17,7 @@ import org.kunlab.scenamatica.nms.impl.v1_16_R2.entity.NMSEntityImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R2.entity.NMSEntityItemImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R2.entity.NMSEntityLivingImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R2.entity.NMSEntityPlayerImpl;
+import org.kunlab.scenamatica.nms.impl.v1_16_R2.entity.NMSLightningStrikeImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R2.item.NMSItemStackImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R2.world.NMSWorldServerImpl;
 import org.kunlab.scenamatica.nms.types.NMSMinecraftServer;
@@ -25,6 +27,7 @@ import org.kunlab.scenamatica.nms.types.entity.NMSEntityHuman;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityPlayer;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
 import org.kunlab.scenamatica.nms.types.world.NMSWorldServer;
 
@@ -58,6 +61,11 @@ public class WrapperProviderImpl implements WrapperProvider
     public static NMSEntityPlayer wrap$(Player bukkitEntity)
     {
         return new NMSEntityPlayerImpl(bukkitEntity);
+    }
+
+    public static NMSLightningStrike wrap$(LightningStrike bukkitLightningStrike)
+    {
+        return new NMSLightningStrikeImpl(bukkitLightningStrike);
     }
 
     public static NMSItemStack wrap$(ItemStack bukkitItemStack)
@@ -103,6 +111,12 @@ public class WrapperProviderImpl implements WrapperProvider
     public NMSEntityPlayer wrap(Player bukkitEntity)
     {
         return wrap$(bukkitEntity);
+    }
+
+    @Override
+    public NMSLightningStrike wrap(LightningStrike bukkitLightningStrike)
+    {
+        return wrap$(bukkitLightningStrike);
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_16_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R2/entity/NMSLightningStrikeImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R2/entity/NMSLightningStrikeImpl.java
@@ -1,0 +1,31 @@
+package org.kunlab.scenamatica.nms.impl.v1_16_R2.entity;
+
+import net.minecraft.server.v1_16_R2.EntityLightning;
+import org.bukkit.craftbukkit.v1_16_R2.entity.CraftLightningStrike;
+import org.bukkit.entity.LightningStrike;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
+
+public class NMSLightningStrikeImpl extends NMSEntityImpl implements NMSLightningStrike
+{
+    private final LightningStrike bukkitLightningStrike;
+    private final EntityLightning nmsLightning;
+
+    public NMSLightningStrikeImpl(LightningStrike bukkitLightningStrike)
+    {
+        super(bukkitLightningStrike);
+        this.bukkitLightningStrike = bukkitLightningStrike;
+        this.nmsLightning = ((CraftLightningStrike) bukkitLightningStrike).getHandle();
+    }
+
+    @Override
+    public void setVisualOnly(boolean visualOnly)
+    {
+        this.nmsLightning.isEffect = visualOnly;
+    }
+
+    @Override
+    public LightningStrike getBukkit()
+    {
+        return this.bukkitLightningStrike;
+    }
+}

--- a/Scenamatica/NMSBridge/v1_16_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R2/item/NMSItemStackImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R2/item/NMSItemStackImpl.java
@@ -3,7 +3,6 @@ package org.kunlab.scenamatica.nms.impl.v1_16_R2.item;
 import net.minecraft.server.v1_16_R2.EntityLiving;
 import net.minecraft.server.v1_16_R2.ItemStack;
 import org.bukkit.craftbukkit.v1_16_R2.inventory.CraftItemStack;
-import org.kunlab.scenamatica.nms.Versioned;
 import org.kunlab.scenamatica.nms.enums.entity.NMSItemSlot;
 import org.kunlab.scenamatica.nms.impl.v1_16_R2.NMSRegistryImpl;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
@@ -73,7 +72,7 @@ public class NMSItemStackImpl implements NMSItemStack
     }
 
     @Override
-    public <T extends NMSEntityLiving> @Versioned void damage(int damage, T owner, NMSItemSlot slot)
+    public <T extends NMSEntityLiving> void damage(int damage, T owner, NMSItemSlot slot)
     {
         this.nmsItemStack.damage(
                 damage,

--- a/Scenamatica/NMSBridge/v1_16_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R2/world/NMSWorldServerImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R2/world/NMSWorldServerImpl.java
@@ -1,12 +1,17 @@
 package org.kunlab.scenamatica.nms.impl.v1_16_R2.world;
 
+import net.minecraft.server.v1_16_R2.EntityLightning;
+import net.minecraft.server.v1_16_R2.EntityTypes;
 import net.minecraft.server.v1_16_R2.BlockPosition;
 import net.minecraft.server.v1_16_R2.WorldServer;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_16_R2.util.CraftMagicNumbers;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LightningStrike;
 import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.nms.enums.entity.NMSLightningStrikeCause;
 import org.kunlab.scenamatica.nms.exceptions.UnsupportedNMSOperationException;
 import org.kunlab.scenamatica.nms.types.world.NMSChunkProvider;
 import org.kunlab.scenamatica.nms.types.world.NMSPersistentEntitySectionManager;
@@ -60,6 +65,22 @@ public class NMSWorldServerImpl implements NMSWorldServer
                 "getEntityManager",
                 NMSPersistentEntitySectionManager.class
         );
+    }
+
+    @Override
+    public void strikeLightning(@NotNull Location location, boolean isEffect, @NotNull NMSLightningStrikeCause cause)
+    {
+        EntityLightning nmsEntity = new EntityLightning(EntityTypes.LIGHTNING_BOLT, this.nmsWorld);
+        nmsEntity.isEffect = isEffect;
+        nmsEntity.setPosition(location.getX(), location.getY(), location.getZ());
+        this.nmsWorld.strikeLightning(nmsEntity);
+    }
+
+    @Override
+    public void strikeLightning(@NotNull LightningStrike strike, @NotNull NMSLightningStrikeCause cause)
+    {
+        EntityLightning lightning = ((org.bukkit.craftbukkit.v1_16_R2.entity.CraftLightningStrike) strike).getHandle();
+        this.nmsWorld.strikeLightning(lightning, NMSLightningStrikeCause.toBukkit(cause));
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_16_R3/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R3/WrapperProviderImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R3/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R3/WrapperProviderImpl.java
@@ -6,6 +6,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -16,6 +17,7 @@ import org.kunlab.scenamatica.nms.impl.v1_16_R3.entity.NMSEntityImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R3.entity.NMSEntityItemImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R3.entity.NMSEntityLivingImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R3.entity.NMSEntityPlayerImpl;
+import org.kunlab.scenamatica.nms.impl.v1_16_R3.entity.NMSLightningStrikeImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R3.item.NMSItemStackImpl;
 import org.kunlab.scenamatica.nms.impl.v1_16_R3.world.NMSWorldServerImpl;
 import org.kunlab.scenamatica.nms.types.NMSMinecraftServer;
@@ -25,6 +27,7 @@ import org.kunlab.scenamatica.nms.types.entity.NMSEntityHuman;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityPlayer;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
 import org.kunlab.scenamatica.nms.types.world.NMSWorldServer;
 
@@ -58,6 +61,11 @@ public class WrapperProviderImpl implements WrapperProvider
     public static NMSEntityPlayer wrap$(Player bukkitEntity)
     {
         return new NMSEntityPlayerImpl(bukkitEntity);
+    }
+
+    public static NMSLightningStrike wrap$(LightningStrike bukkitLightningStrike)
+    {
+        return new NMSLightningStrikeImpl(bukkitLightningStrike);
     }
 
     public static NMSItemStack wrap$(ItemStack bukkitItemStack)
@@ -103,6 +111,12 @@ public class WrapperProviderImpl implements WrapperProvider
     public NMSEntityPlayer wrap(Player bukkitEntity)
     {
         return wrap$(bukkitEntity);
+    }
+
+    @Override
+    public NMSLightningStrike wrap(LightningStrike bukkitLightningStrike)
+    {
+        return wrap$(bukkitLightningStrike);
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_16_R3/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R3/entity/NMSLightningStrikeImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R3/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R3/entity/NMSLightningStrikeImpl.java
@@ -1,0 +1,31 @@
+package org.kunlab.scenamatica.nms.impl.v1_16_R3.entity;
+
+import net.minecraft.server.v1_16_R3.EntityLightning;
+import org.bukkit.craftbukkit.v1_16_R3.entity.CraftLightningStrike;
+import org.bukkit.entity.LightningStrike;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
+
+public class NMSLightningStrikeImpl extends NMSEntityImpl implements NMSLightningStrike
+{
+    private final LightningStrike bukkitLightningStrike;
+    private final EntityLightning nmsLightning;
+
+    public NMSLightningStrikeImpl(LightningStrike bukkitLightningStrike)
+    {
+        super(bukkitLightningStrike);
+        this.bukkitLightningStrike = bukkitLightningStrike;
+        this.nmsLightning = ((CraftLightningStrike) bukkitLightningStrike).getHandle();
+    }
+
+    @Override
+    public void setVisualOnly(boolean visualOnly)
+    {
+        this.nmsLightning.isEffect = visualOnly;
+    }
+
+    @Override
+    public LightningStrike getBukkit()
+    {
+        return this.bukkitLightningStrike;
+    }
+}

--- a/Scenamatica/NMSBridge/v1_16_R3/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R3/item/NMSItemStackImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R3/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R3/item/NMSItemStackImpl.java
@@ -3,7 +3,6 @@ package org.kunlab.scenamatica.nms.impl.v1_16_R3.item;
 import net.minecraft.server.v1_16_R3.EntityLiving;
 import net.minecraft.server.v1_16_R3.ItemStack;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftItemStack;
-import org.kunlab.scenamatica.nms.Versioned;
 import org.kunlab.scenamatica.nms.enums.entity.NMSItemSlot;
 import org.kunlab.scenamatica.nms.impl.v1_16_R3.NMSRegistryImpl;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
@@ -73,7 +72,7 @@ public class NMSItemStackImpl implements NMSItemStack
     }
 
     @Override
-    public <T extends NMSEntityLiving> @Versioned void damage(int damage, T owner, NMSItemSlot slot)
+    public <T extends NMSEntityLiving> void damage(int damage, T owner, NMSItemSlot slot)
     {
         this.nmsItemStack.damage(
                 damage,

--- a/Scenamatica/NMSBridge/v1_16_R3/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R3/world/NMSWorldServerImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R3/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R3/world/NMSWorldServerImpl.java
@@ -1,12 +1,17 @@
 package org.kunlab.scenamatica.nms.impl.v1_16_R3.world;
 
+import net.minecraft.server.v1_16_R3.EntityLightning;
+import net.minecraft.server.v1_16_R3.EntityTypes;
 import net.minecraft.server.v1_16_R3.BlockPosition;
 import net.minecraft.server.v1_16_R3.WorldServer;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_16_R3.util.CraftMagicNumbers;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LightningStrike;
 import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.nms.enums.entity.NMSLightningStrikeCause;
 import org.kunlab.scenamatica.nms.exceptions.UnsupportedNMSOperationException;
 import org.kunlab.scenamatica.nms.types.world.NMSChunkProvider;
 import org.kunlab.scenamatica.nms.types.world.NMSPersistentEntitySectionManager;
@@ -60,6 +65,22 @@ public class NMSWorldServerImpl implements NMSWorldServer
                 "getEntityManager",
                 NMSPersistentEntitySectionManager.class
         );
+    }
+
+    @Override
+    public void strikeLightning(@NotNull Location location, boolean isEffect, @NotNull NMSLightningStrikeCause cause)
+    {
+        EntityLightning nmsEntity = new EntityLightning(EntityTypes.LIGHTNING_BOLT, this.nmsWorld);
+        nmsEntity.isEffect = isEffect;
+        nmsEntity.setPosition(location.getX(), location.getY(), location.getZ());
+        this.nmsWorld.strikeLightning(nmsEntity);
+    }
+
+    @Override
+    public void strikeLightning(@NotNull LightningStrike strike, @NotNull NMSLightningStrikeCause cause)
+    {
+        EntityLightning lightning = ((org.bukkit.craftbukkit.v1_16_R3.entity.CraftLightningStrike) strike).getHandle();
+        this.nmsWorld.strikeLightning(lightning, NMSLightningStrikeCause.toBukkit(cause));
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_17_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_17_R1/WrapperProviderImpl.java
+++ b/Scenamatica/NMSBridge/v1_17_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_17_R1/WrapperProviderImpl.java
@@ -6,6 +6,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -16,6 +17,7 @@ import org.kunlab.scenamatica.nms.impl.v1_17_R1.entity.NMSEntityImpl;
 import org.kunlab.scenamatica.nms.impl.v1_17_R1.entity.NMSEntityItemImpl;
 import org.kunlab.scenamatica.nms.impl.v1_17_R1.entity.NMSEntityLivingImpl;
 import org.kunlab.scenamatica.nms.impl.v1_17_R1.entity.NMSEntityPlayerImpl;
+import org.kunlab.scenamatica.nms.impl.v1_17_R1.entity.NMSLightningStrikeImpl;
 import org.kunlab.scenamatica.nms.impl.v1_17_R1.item.NMSItemStackImpl;
 import org.kunlab.scenamatica.nms.impl.v1_17_R1.world.NMSWorldServerImpl;
 import org.kunlab.scenamatica.nms.types.NMSMinecraftServer;
@@ -25,6 +27,7 @@ import org.kunlab.scenamatica.nms.types.entity.NMSEntityHuman;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityPlayer;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
 import org.kunlab.scenamatica.nms.types.world.NMSWorldServer;
 
@@ -58,6 +61,11 @@ public class WrapperProviderImpl implements WrapperProvider
     public static NMSEntityPlayer wrap$(Player bukkitEntity)
     {
         return new NMSEntityPlayerImpl(bukkitEntity);
+    }
+
+    public static NMSLightningStrike wrap$(LightningStrike bukkitLightningStrike)
+    {
+        return new NMSLightningStrikeImpl(bukkitLightningStrike);
     }
 
     public static NMSItemStack wrap$(ItemStack bukkitItemStack)
@@ -103,6 +111,12 @@ public class WrapperProviderImpl implements WrapperProvider
     public NMSEntityPlayer wrap(Player bukkitEntity)
     {
         return wrap$(bukkitEntity);
+    }
+
+    @Override
+    public NMSLightningStrike wrap(LightningStrike bukkitLightningStrike)
+    {
+        return wrap$(bukkitLightningStrike);
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_17_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_17_R1/entity/NMSLightningStrikeImpl.java
+++ b/Scenamatica/NMSBridge/v1_17_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_17_R1/entity/NMSLightningStrikeImpl.java
@@ -1,0 +1,31 @@
+package org.kunlab.scenamatica.nms.impl.v1_17_R1.entity;
+
+import net.minecraft.world.entity.EntityLightning;
+import org.bukkit.craftbukkit.v1_17_R1.entity.CraftLightningStrike;
+import org.bukkit.entity.LightningStrike;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
+
+public class NMSLightningStrikeImpl extends NMSEntityImpl implements NMSLightningStrike
+{
+    private final LightningStrike bukkitLightningStrike;
+    private final EntityLightning nmsLightning;
+
+    public NMSLightningStrikeImpl(LightningStrike bukkitLightningStrike)
+    {
+        super(bukkitLightningStrike);
+        this.bukkitLightningStrike = bukkitLightningStrike;
+        this.nmsLightning = ((CraftLightningStrike) bukkitLightningStrike).getHandle();
+    }
+
+    @Override
+    public void setVisualOnly(boolean visualOnly)
+    {
+        this.nmsLightning.ap = visualOnly;
+    }
+
+    @Override
+    public LightningStrike getBukkit()
+    {
+        return this.bukkitLightningStrike;
+    }
+}

--- a/Scenamatica/NMSBridge/v1_17_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_17_R1/item/NMSItemStackImpl.java
+++ b/Scenamatica/NMSBridge/v1_17_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_17_R1/item/NMSItemStackImpl.java
@@ -3,7 +3,6 @@ package org.kunlab.scenamatica.nms.impl.v1_17_R1.item;
 import net.minecraft.world.entity.EntityLiving;
 import net.minecraft.world.item.ItemStack;
 import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftItemStack;
-import org.kunlab.scenamatica.nms.Versioned;
 import org.kunlab.scenamatica.nms.enums.entity.NMSItemSlot;
 import org.kunlab.scenamatica.nms.impl.v1_17_R1.NMSRegistryImpl;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
@@ -73,7 +72,7 @@ public class NMSItemStackImpl implements NMSItemStack
     }
 
     @Override
-    public <T extends NMSEntityLiving> @Versioned void damage(int damage, T owner, NMSItemSlot slot)
+    public <T extends NMSEntityLiving> void damage(int damage, T owner, NMSItemSlot slot)
     {
         this.nmsItemStack.damage(
                 damage,

--- a/Scenamatica/NMSBridge/v1_17_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_17_R1/world/NMSWorldServerImpl.java
+++ b/Scenamatica/NMSBridge/v1_17_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_17_R1/world/NMSWorldServerImpl.java
@@ -2,11 +2,16 @@ package org.kunlab.scenamatica.nms.impl.v1_17_R1.world;
 
 import net.minecraft.core.BlockPosition;
 import net.minecraft.server.level.WorldServer;
+import net.minecraft.world.entity.EntityLightning;
+import net.minecraft.world.entity.EntityTypes;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_17_R1.util.CraftMagicNumbers;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LightningStrike;
 import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.nms.enums.entity.NMSLightningStrikeCause;
 import org.kunlab.scenamatica.nms.types.world.NMSChunkProvider;
 import org.kunlab.scenamatica.nms.types.world.NMSPersistentEntitySectionManager;
 import org.kunlab.scenamatica.nms.types.world.NMSWorldData;
@@ -57,6 +62,22 @@ public class NMSWorldServerImpl implements NMSWorldServer
     public @NotNull NMSPersistentEntitySectionManager<Entity> getEntityManager()
     {
         return this.entityManager;
+    }
+
+    @Override
+    public void strikeLightning(@NotNull Location location, boolean isEffect, @NotNull NMSLightningStrikeCause cause)
+    {
+        EntityLightning nmsEntity = new EntityLightning(EntityTypes.U, this.nmsWorld);
+        nmsEntity.ap = isEffect;
+        nmsEntity.setPosition(location.getX(), location.getY(), location.getZ());
+        this.nmsWorld.strikeLightning(nmsEntity);
+    }
+
+    @Override
+    public void strikeLightning(@NotNull LightningStrike strike, @NotNull NMSLightningStrikeCause cause)
+    {
+        EntityLightning lightning = ((org.bukkit.craftbukkit.v1_17_R1.entity.CraftLightningStrike) strike).getHandle();
+        this.nmsWorld.strikeLightning(lightning, NMSLightningStrikeCause.toBukkit(cause));
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_18_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_18_R1/WrapperProviderImpl.java
+++ b/Scenamatica/NMSBridge/v1_18_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_18_R1/WrapperProviderImpl.java
@@ -6,6 +6,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -16,6 +17,7 @@ import org.kunlab.scenamatica.nms.impl.v1_18_R1.entity.NMSEntityImpl;
 import org.kunlab.scenamatica.nms.impl.v1_18_R1.entity.NMSEntityItemImpl;
 import org.kunlab.scenamatica.nms.impl.v1_18_R1.entity.NMSEntityLivingImpl;
 import org.kunlab.scenamatica.nms.impl.v1_18_R1.entity.NMSEntityPlayerImpl;
+import org.kunlab.scenamatica.nms.impl.v1_18_R1.entity.NMSLightningStrikeImpl;
 import org.kunlab.scenamatica.nms.impl.v1_18_R1.item.NMSItemStackImpl;
 import org.kunlab.scenamatica.nms.impl.v1_18_R1.world.NMSWorldServerImpl;
 import org.kunlab.scenamatica.nms.types.NMSMinecraftServer;
@@ -25,6 +27,7 @@ import org.kunlab.scenamatica.nms.types.entity.NMSEntityHuman;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityPlayer;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
 import org.kunlab.scenamatica.nms.types.world.NMSWorldServer;
 
@@ -58,6 +61,11 @@ public class WrapperProviderImpl implements WrapperProvider
     public static NMSEntityPlayer wrap$(Player bukkitEntity)
     {
         return new NMSEntityPlayerImpl(bukkitEntity);
+    }
+
+    public static NMSLightningStrike wrap$(LightningStrike bukkitLightningStrike)
+    {
+        return new NMSLightningStrikeImpl(bukkitLightningStrike);
     }
 
     public static NMSItemStack wrap$(ItemStack bukkitItemStack)
@@ -103,6 +111,12 @@ public class WrapperProviderImpl implements WrapperProvider
     public NMSEntityPlayer wrap(Player bukkitEntity)
     {
         return wrap$(bukkitEntity);
+    }
+
+    @Override
+    public NMSLightningStrike wrap(LightningStrike bukkitLightningStrike)
+    {
+        return wrap$(bukkitLightningStrike);
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_18_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_18_R1/entity/NMSLightningStrikeImpl.java
+++ b/Scenamatica/NMSBridge/v1_18_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_18_R1/entity/NMSLightningStrikeImpl.java
@@ -1,0 +1,31 @@
+package org.kunlab.scenamatica.nms.impl.v1_18_R1.entity;
+
+import net.minecraft.world.entity.LightningBolt;
+import org.bukkit.craftbukkit.v1_18_R1.entity.CraftLightningStrike;
+import org.bukkit.entity.LightningStrike;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
+
+public class NMSLightningStrikeImpl extends NMSEntityImpl implements NMSLightningStrike
+{
+    private final LightningStrike bukkitLightningStrike;
+    private final LightningBolt nmsLightning;
+
+    public NMSLightningStrikeImpl(LightningStrike bukkitLightningStrike)
+    {
+        super(bukkitLightningStrike);
+        this.bukkitLightningStrike = bukkitLightningStrike;
+        this.nmsLightning = ((CraftLightningStrike) bukkitLightningStrike).getHandle();
+    }
+
+    @Override
+    public void setVisualOnly(boolean visualOnly)
+    {
+        this.nmsLightning.visualOnly = visualOnly;
+    }
+
+    @Override
+    public LightningStrike getBukkit()
+    {
+        return this.bukkitLightningStrike;
+    }
+}

--- a/Scenamatica/NMSBridge/v1_18_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_18_R1/item/NMSItemStackImpl.java
+++ b/Scenamatica/NMSBridge/v1_18_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_18_R1/item/NMSItemStackImpl.java
@@ -3,7 +3,6 @@ package org.kunlab.scenamatica.nms.impl.v1_18_R1.item;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import org.bukkit.craftbukkit.v1_18_R1.inventory.CraftItemStack;
-import org.kunlab.scenamatica.nms.Versioned;
 import org.kunlab.scenamatica.nms.enums.entity.NMSItemSlot;
 import org.kunlab.scenamatica.nms.impl.v1_18_R1.NMSRegistryImpl;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityLiving;
@@ -73,7 +72,7 @@ public class NMSItemStackImpl implements NMSItemStack
     }
 
     @Override
-    public <T extends NMSEntityLiving> @Versioned void damage(int damage, T owner, NMSItemSlot slot)
+    public <T extends NMSEntityLiving> void damage(int damage, T owner, NMSItemSlot slot)
     {
         this.nmsItemStack.hurtAndBreak(
                 damage,

--- a/Scenamatica/NMSBridge/v1_18_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_18_R1/world/NMSWorldServerImpl.java
+++ b/Scenamatica/NMSBridge/v1_18_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_18_R1/world/NMSWorldServerImpl.java
@@ -2,12 +2,18 @@ package org.kunlab.scenamatica.nms.impl.v1_18_R1.world;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LightningBolt;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_18_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_18_R1.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_18_R1.entity.CraftLightningStrike;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LightningStrike;
 import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.nms.enums.entity.NMSLightningStrikeCause;
 import org.kunlab.scenamatica.nms.types.world.NMSChunkProvider;
 import org.kunlab.scenamatica.nms.types.world.NMSPersistentEntitySectionManager;
 import org.kunlab.scenamatica.nms.types.world.NMSWorldData;
@@ -58,6 +64,22 @@ public class NMSWorldServerImpl implements NMSWorldServer
     public @NotNull NMSPersistentEntitySectionManager<Entity> getEntityManager()
     {
         return this.entityManager;
+    }
+
+    @Override
+    public void strikeLightning(@NotNull Location location, boolean isEffect, @NotNull NMSLightningStrikeCause cause)
+    {
+        LightningBolt nmsEntity = new LightningBolt(EntityType.LIGHTNING_BOLT, this.nmsWorld);
+        nmsEntity.setVisualOnly(isEffect);
+        nmsEntity.setPos(location.getX(), location.getY(), location.getZ());
+        this.nmsWorld.strikeLightning(nmsEntity);
+    }
+
+    @Override
+    public void strikeLightning(@NotNull LightningStrike strike, @NotNull NMSLightningStrikeCause cause)
+    {
+        net.minecraft.world.entity.Entity nmsEntity = ((CraftLightningStrike) strike).getHandle();
+        this.nmsWorld.strikeLightning(nmsEntity, NMSLightningStrikeCause.toBukkit(cause));
     }
 
     @Override

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/WorldLoadAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/WorldLoadAction.java
@@ -58,7 +58,7 @@ public class WorldLoadAction extends AbstractWorldAction
     public boolean checkConditionFulfilled(@NotNull ActionContext ctxt)
     {
         World world;
-        boolean result = (world = super.getWorld(ctxt)) != null;
+        boolean result = (world = super.getWorldNonNull(ctxt)) != null;
         if (result)
             this.makeOutputs(ctxt, world);
         return result;

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/WorldUnloadAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/WorldUnloadAction.java
@@ -42,7 +42,7 @@ public class WorldUnloadAction extends AbstractWorldAction
     @Override
     public void execute(@NotNull ActionContext ctxt)
     {
-        World world = super.getWorld(ctxt);
+        World world = super.getWorldNonNull(ctxt);
 
         if (world == null)
             throw new IllegalActionInputException(IN_WORLD, "Unable to find world: " + ctxt.input(IN_WORLD));

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/AbstractWeatherAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/AbstractWeatherAction.java
@@ -1,0 +1,20 @@
+package org.kunlab.scenamatica.action.actions.base.world.weather;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.weather.WeatherEvent;
+import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.action.actions.base.world.AbstractWorldAction;
+import org.kunlab.scenamatica.interfaces.action.ActionContext;
+
+public abstract class AbstractWeatherAction extends AbstractWorldAction
+{
+    @Override
+    public boolean checkFired(@NotNull ActionContext ctxt, @NotNull Event event)
+    {
+        if (!(event instanceof WeatherEvent))
+            return false;
+
+        WeatherEvent e = (WeatherEvent) event;
+        return this.checkMatchedWorld(ctxt, e.getWorld());
+    }
+}

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherChangeAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherChangeAction.java
@@ -4,6 +4,7 @@ import org.bukkit.World;
 import org.bukkit.event.Event;
 import org.bukkit.event.weather.WeatherChangeEvent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.kunlab.scenamatica.annotations.action.Action;
 import org.kunlab.scenamatica.bookkeeper.annotations.ActionDoc;
 import org.kunlab.scenamatica.bookkeeper.annotations.Admonition;
@@ -119,6 +120,7 @@ public class WeatherChangeAction extends AbstractWeatherAction
         else
             changeToRaining = !world.hasStorm();
 
+        this.makeOutputs(ctxt, world, changeToRaining, duration);
         world.setStorm(changeToRaining);
         world.setWeatherDuration(duration);
     }
@@ -133,7 +135,19 @@ public class WeatherChangeAction extends AbstractWeatherAction
         if (!super.checkMatchedWorld(ctxt, e.getWorld()))
             return false;
 
-        return ctxt.ifHasInput(IN_RAINING, r -> e.toWeatherState() == r);
+        boolean result = ctxt.ifHasInput(IN_RAINING, r -> e.toWeatherState() == r);
+        if (result)
+            this.makeOutputs(ctxt, e.getWorld(), e.toWeatherState(), null);
+
+        return result;
+    }
+
+    private void makeOutputs(@NotNull ActionContext ctxt, @NotNull World world, boolean raining, @Nullable Integer duration)
+    {
+        ctxt.output(OUTPUT_RAINING, raining);
+        if (duration != null)
+            ctxt.output(OUTPUT_DURATION, duration);
+        super.makeOutputs(ctxt, world);
     }
 
     @Override

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherChangeAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherChangeAction.java
@@ -49,6 +49,14 @@ import java.util.List;
                                 )
                         }
                 )
+        },
+
+        admonitions = {
+                @Admonition(
+                        type = AdmonitionType.NOTE,
+                        title = "雷について",
+                        content = "雷の発生状態を変更する場合は, `weather_change_thunder` アクションを使用してください。"
+                )
         }
 )
 public class WeatherChangeAction extends AbstractWeatherAction

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherChangeAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherChangeAction.java
@@ -1,0 +1,137 @@
+package org.kunlab.scenamatica.action.actions.base.world.weather;
+
+import org.bukkit.World;
+import org.bukkit.event.Event;
+import org.bukkit.event.weather.WeatherChangeEvent;
+import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.annotations.action.Action;
+import org.kunlab.scenamatica.bookkeeper.annotations.ActionDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.Admonition;
+import org.kunlab.scenamatica.bookkeeper.annotations.InputDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.OutputDoc;
+import org.kunlab.scenamatica.bookkeeper.enums.ActionMethod;
+import org.kunlab.scenamatica.bookkeeper.enums.AdmonitionType;
+import org.kunlab.scenamatica.enums.ScenarioType;
+import org.kunlab.scenamatica.interfaces.action.ActionContext;
+import org.kunlab.scenamatica.interfaces.action.input.InputBoard;
+import org.kunlab.scenamatica.interfaces.action.input.InputToken;
+import org.kunlab.scenamatica.interfaces.action.types.Executable;
+import org.kunlab.scenamatica.interfaces.action.types.Expectable;
+
+import java.util.Collections;
+import java.util.List;
+
+@Action("weather_change")
+@ActionDoc(
+        name = "天候の变化",
+        description = "ワールドの天候を変更します。",
+        events = WeatherChangeEvent.class,
+
+        executable = "ワールドの天候を変更します。",
+        expectable = "ワールドの天候が変わるまで待機します。",
+        requireable = ActionDoc.UNALLOWED,
+
+        outputs = {
+                @OutputDoc(
+                        name = WeatherChangeAction.OUTPUT_RAINING,
+                        description = "雨（または雪）が降っているかを出力します。",
+                        type = Boolean.class
+                ),
+                @OutputDoc(
+                        name = WeatherChangeAction.OUTPUT_DURATION,
+                        description = "その天候が続く期間（チック）を出力します。",
+                        type = Integer.class,
+
+                        admonitions = {
+                                @Admonition(
+                                        type = AdmonitionType.INFORMATION,
+                                        content = "この値が `0` の場合は, その天候が永久に続くことを意味します。"
+                                )
+                        }
+                )
+        }
+)
+public class WeatherChangeAction extends AbstractWeatherAction
+        implements Executable, Expectable
+{
+    public static final String OUTPUT_RAINING = "raining";
+    public static final String OUTPUT_DURATION = "duration";
+
+    @InputDoc(
+            name = "raining",
+            description = "雨（または雪）が降っているかどうかを指定します。",
+            type = Boolean.class,
+
+            admonitions = {
+                    @Admonition(
+                            type = AdmonitionType.INFORMATION,
+                            on = ActionMethod.EXECUTE,
+                            content = "この値を指定しない場合は, 今とは逆の天候に変更されます。\n" +
+                                    "雨（または雪）の場合は晴れに, 晴れの場合は雨（または雪）に変更されます。"
+                    )
+            }
+    )
+    public static final InputToken<Boolean> IN_RAINING = ofInput("raining", Boolean.class);
+
+    @InputDoc(
+            name = "duration",
+            description = "その天候が続く期間（チック）を指定します。",
+            type = Integer.class,
+            availableFor = {ActionMethod.EXECUTE},
+
+            admonitions = {
+                    @Admonition(
+                            type = AdmonitionType.INFORMATION,
+                            on = ActionMethod.EXECUTE,
+                            content = "この値を指定しなかった場合は, 自動的に `0` が設定されます。"
+                    ),
+                    @Admonition(
+                            type = AdmonitionType.INFORMATION,
+                            content = "この値が `0` の場合は, その天候が永久に続くことを意味します。"
+                    )
+            }
+    )
+    public static final InputToken<Integer> IN_DURATION = ofInput("duration", Integer.class);
+
+    @Override
+    public List<Class<? extends Event>> getAttachingEvents()
+    {
+        return Collections.singletonList(WeatherChangeEvent.class);
+    }
+
+    @Override
+    public void execute(@NotNull ActionContext ctxt)
+    {
+        World world = this.getWorldNonNull(ctxt);
+
+        int duration = ctxt.orElseInput(IN_DURATION, () -> 0);
+        boolean changeToRaining;
+        if (ctxt.hasInput(IN_RAINING))
+            changeToRaining = ctxt.input(IN_RAINING);
+        else
+            changeToRaining = !world.hasStorm();
+
+        world.setStorm(changeToRaining);
+        world.setWeatherDuration(duration);
+    }
+
+    @Override
+    public boolean checkFired(@NotNull ActionContext ctxt, @NotNull Event event)
+    {
+        if (!(event instanceof WeatherChangeEvent))
+            return false;
+
+        WeatherChangeEvent e = (WeatherChangeEvent) event;
+        if (!super.checkMatchedWorld(ctxt, e.getWorld()))
+            return false;
+
+        return ctxt.ifHasInput(IN_RAINING, r -> e.toWeatherState() == r);
+    }
+
+    @Override
+    public InputBoard getInputBoard(ScenarioType type)
+    {
+        return super.getInputBoard(type)
+                .registerAll(IN_RAINING, IN_DURATION);
+    }
+}

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherChangeThunderAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherChangeThunderAction.java
@@ -4,6 +4,7 @@ import org.bukkit.World;
 import org.bukkit.event.Event;
 import org.bukkit.event.weather.ThunderChangeEvent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.kunlab.scenamatica.annotations.action.Action;
 import org.kunlab.scenamatica.bookkeeper.annotations.ActionDoc;
 import org.kunlab.scenamatica.bookkeeper.annotations.Admonition;
@@ -104,6 +105,7 @@ public class WeatherChangeThunderAction extends AbstractWeatherAction
         else
             changeToThundering = !world.hasStorm();
 
+        this.makeOutputs(ctxt, world, changeToThundering, duration);
         world.setThundering(changeToThundering);
         world.setThunderDuration(duration);
     }
@@ -118,7 +120,19 @@ public class WeatherChangeThunderAction extends AbstractWeatherAction
         if (!super.checkMatchedWorld(ctxt, e.getWorld()))
             return false;
 
-        return ctxt.ifHasInput(INPUT_THUNDERING, r -> e.toThunderState() == r);
+        boolean result = ctxt.ifHasInput(INPUT_THUNDERING, r -> e.toThunderState() == r);
+        if (result)
+            this.makeOutputs(ctxt, e.getWorld(), e.toThunderState(), null);
+
+        return result;
+    }
+
+    private void makeOutputs(@NotNull ActionContext ctxt, @NotNull World world, boolean thundering, @Nullable Integer duration)
+    {
+        ctxt.output(OUTPUT_THUNDERING, thundering);
+        if (duration != null)
+            ctxt.output(OUTPUT_DURATION, duration);
+        super.makeOutputs(ctxt, world);
     }
 
     @Override

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherChangeThunderAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherChangeThunderAction.java
@@ -12,7 +12,9 @@ import org.kunlab.scenamatica.bookkeeper.annotations.InputDoc;
 import org.kunlab.scenamatica.bookkeeper.annotations.OutputDoc;
 import org.kunlab.scenamatica.bookkeeper.enums.ActionMethod;
 import org.kunlab.scenamatica.bookkeeper.enums.AdmonitionType;
+import org.kunlab.scenamatica.enums.ScenarioType;
 import org.kunlab.scenamatica.interfaces.action.ActionContext;
+import org.kunlab.scenamatica.interfaces.action.input.InputBoard;
 import org.kunlab.scenamatica.interfaces.action.input.InputToken;
 import org.kunlab.scenamatica.interfaces.action.types.Executable;
 import org.kunlab.scenamatica.interfaces.action.types.Expectable;
@@ -32,12 +34,12 @@ import java.util.List;
 
         outputs = {
                 @OutputDoc(
-                        name = WeatherChangeThunderAction.OUTPUT_THUNDERING,
+                        name = WeatherChangeThunderAction.OUT_THUNDERING,
                         description = "雷が発生しているかを出力します。",
                         type = Boolean.class
                 ),
                 @OutputDoc(
-                        name = WeatherChangeThunderAction.OUTPUT_DURATION,
+                        name = WeatherChangeThunderAction.OUT_DURATION,
                         description = "その雷が続く期間（チック）を出力します。",
                         type = Integer.class
                 )
@@ -54,8 +56,8 @@ import java.util.List;
 public class WeatherChangeThunderAction extends AbstractWeatherAction
         implements Executable, Expectable
 {
-    public static final String OUTPUT_THUNDERING = "thundering";
-    public static final String OUTPUT_DURATION = "duration";
+    public static final String OUT_THUNDERING = "thundering";
+    public static final String OUT_DURATION = "duration";
 
     @InputDoc(
             name = "雷の発生状態",
@@ -71,7 +73,7 @@ public class WeatherChangeThunderAction extends AbstractWeatherAction
                     )
             }
     )
-    public static final InputToken<Boolean> INPUT_THUNDERING = ofInput("thundering", Boolean.class);
+    public static final InputToken<Boolean> IN_THUNDERING = ofInput("thundering", Boolean.class);
 
     @InputDoc(
             name = "雷の継続時間",
@@ -91,17 +93,17 @@ public class WeatherChangeThunderAction extends AbstractWeatherAction
                     )
             }
     )
-    public static final InputToken<Integer> INPUT_DURATION = ofInput("duration", Integer.class);
+    public static final InputToken<Integer> IN_DURATION = ofInput("duration", Integer.class);
 
     @Override
     public void execute(@NotNull ActionContext ctxt)
     {
         World world = this.getWorldNonNull(ctxt);
 
-        int duration = ctxt.orElseInput(INPUT_DURATION, () -> 0);
+        int duration = ctxt.orElseInput(IN_DURATION, () -> 0);
         boolean changeToThundering;
-        if (ctxt.hasInput(INPUT_THUNDERING))
-            changeToThundering = ctxt.input(INPUT_THUNDERING);
+        if (ctxt.hasInput(IN_THUNDERING))
+            changeToThundering = ctxt.input(IN_THUNDERING);
         else
             changeToThundering = !world.hasStorm();
 
@@ -120,7 +122,7 @@ public class WeatherChangeThunderAction extends AbstractWeatherAction
         if (!super.checkMatchedWorld(ctxt, e.getWorld()))
             return false;
 
-        boolean result = ctxt.ifHasInput(INPUT_THUNDERING, r -> e.toThunderState() == r);
+        boolean result = ctxt.ifHasInput(IN_THUNDERING, r -> e.toThunderState() == r);
         if (result)
             this.makeOutputs(ctxt, e.getWorld(), e.toThunderState(), null);
 
@@ -129,10 +131,17 @@ public class WeatherChangeThunderAction extends AbstractWeatherAction
 
     private void makeOutputs(@NotNull ActionContext ctxt, @NotNull World world, boolean thundering, @Nullable Integer duration)
     {
-        ctxt.output(OUTPUT_THUNDERING, thundering);
+        ctxt.output(OUT_THUNDERING, thundering);
         if (duration != null)
-            ctxt.output(OUTPUT_DURATION, duration);
+            ctxt.output(OUT_DURATION, duration);
         super.makeOutputs(ctxt, world);
+    }
+
+    @Override
+    public InputBoard getInputBoard(ScenarioType type)
+    {
+        return super.getInputBoard(type)
+                .registerAll(IN_THUNDERING, IN_DURATION);
     }
 
     @Override

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherChangeThunderAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherChangeThunderAction.java
@@ -1,0 +1,131 @@
+package org.kunlab.scenamatica.action.actions.base.world.weather;
+
+import org.bukkit.World;
+import org.bukkit.event.Event;
+import org.bukkit.event.weather.ThunderChangeEvent;
+import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.annotations.action.Action;
+import org.kunlab.scenamatica.bookkeeper.annotations.ActionDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.Admonition;
+import org.kunlab.scenamatica.bookkeeper.annotations.InputDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.OutputDoc;
+import org.kunlab.scenamatica.bookkeeper.enums.ActionMethod;
+import org.kunlab.scenamatica.bookkeeper.enums.AdmonitionType;
+import org.kunlab.scenamatica.interfaces.action.ActionContext;
+import org.kunlab.scenamatica.interfaces.action.input.InputToken;
+import org.kunlab.scenamatica.interfaces.action.types.Executable;
+import org.kunlab.scenamatica.interfaces.action.types.Expectable;
+
+import java.util.Collections;
+import java.util.List;
+
+@Action("weather_change_thunder")
+@ActionDoc(
+        name = "雷の変更",
+        description = "ワールドで雷が発生しているかどうかを変更します。",
+        events = ThunderChangeEvent.class,
+
+        executable = "ワールドで雷が発生しているかどうかを変更します。",
+        expectable = "ワールドの雷の発生状態が変わるまで待機します。",
+        requireable = ActionDoc.UNALLOWED,
+
+        outputs = {
+                @OutputDoc(
+                        name = WeatherChangeThunderAction.OUTPUT_THUNDERING,
+                        description = "雷が発生しているかを出力します。",
+                        type = Boolean.class
+                ),
+                @OutputDoc(
+                        name = WeatherChangeThunderAction.OUTPUT_DURATION,
+                        description = "その雷が続く期間（チック）を出力します。",
+                        type = Integer.class
+                )
+        },
+
+        admonitions = {
+                @Admonition(
+                        type = AdmonitionType.NOTE,
+                        title = "天候について",
+                        content = "その他の天候状態を変更する場合は, `weather_change` アクションを使用してください。"
+                )
+        }
+)
+public class WeatherChangeThunderAction extends AbstractWeatherAction
+        implements Executable, Expectable
+{
+    public static final String OUTPUT_THUNDERING = "thundering";
+    public static final String OUTPUT_DURATION = "duration";
+
+    @InputDoc(
+            name = "雷の発生状態",
+            description = "雷が発生しているかを設定します。",
+            type = Boolean.class,
+
+            admonitions = {
+                    @Admonition(
+                            type = AdmonitionType.INFORMATION,
+                            on = ActionMethod.EXECUTE,
+                            content = "この値を指定しない場合は, 今とは逆の天候に変更されます。\n" +
+                                    "雷の場合は晴れに, 晴れの場合は雷に変更されます。"
+                    )
+            }
+    )
+    public static final InputToken<Boolean> INPUT_THUNDERING = ofInput("thundering", Boolean.class);
+
+    @InputDoc(
+            name = "雷の継続時間",
+            description = "雷が続く期間（チック）を設定します。",
+            type = Integer.class,
+            availableFor = {ActionMethod.EXECUTE},
+
+            admonitions = {
+                    @Admonition(
+                            type = AdmonitionType.INFORMATION,
+                            on = ActionMethod.EXECUTE,
+                            content = "この値を指定しなかった場合は, 自動的に `0` が設定されます。"
+                    ),
+                    @Admonition(
+                            type = AdmonitionType.INFORMATION,
+                            content = "この値が `0` の場合は, その雷の状態が永久に続くことを意味します。"
+                    )
+            }
+    )
+    public static final InputToken<Integer> INPUT_DURATION = ofInput("duration", Integer.class);
+
+    @Override
+    public void execute(@NotNull ActionContext ctxt)
+    {
+        World world = this.getWorldNonNull(ctxt);
+
+        int duration = ctxt.orElseInput(INPUT_DURATION, () -> 0);
+        boolean changeToThundering;
+        if (ctxt.hasInput(INPUT_THUNDERING))
+            changeToThundering = ctxt.input(INPUT_THUNDERING);
+        else
+            changeToThundering = !world.hasStorm();
+
+        world.setThundering(changeToThundering);
+        world.setThunderDuration(duration);
+    }
+
+    @Override
+    public boolean checkFired(@NotNull ActionContext ctxt, @NotNull Event event)
+    {
+        if (!(event instanceof ThunderChangeEvent))
+            return false;
+
+        ThunderChangeEvent e = (ThunderChangeEvent) event;
+        if (!super.checkMatchedWorld(ctxt, e.getWorld()))
+            return false;
+
+        return ctxt.ifHasInput(INPUT_THUNDERING, r -> e.toThunderState() == r);
+    }
+
+    @Override
+    public List<Class<? extends Event>> getAttachingEvents()
+    {
+        return Collections.singletonList(
+                ThunderChangeEvent.class
+        );
+    }
+}

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherStrikeLightningAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/world/weather/WeatherStrikeLightningAction.java
@@ -1,0 +1,133 @@
+package org.kunlab.scenamatica.action.actions.base.world.weather;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.event.Event;
+import org.bukkit.event.weather.LightningStrikeEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.kunlab.scenamatica.annotations.action.Action;
+import org.kunlab.scenamatica.bookkeeper.annotations.ActionDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.InputDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.OutputDoc;
+import org.kunlab.scenamatica.enums.MinecraftVersion;
+import org.kunlab.scenamatica.enums.ScenarioType;
+import org.kunlab.scenamatica.exceptions.scenario.IllegalActionInputException;
+import org.kunlab.scenamatica.interfaces.action.ActionContext;
+import org.kunlab.scenamatica.interfaces.action.input.InputBoard;
+import org.kunlab.scenamatica.interfaces.action.input.InputToken;
+import org.kunlab.scenamatica.interfaces.action.types.Executable;
+import org.kunlab.scenamatica.interfaces.action.types.Expectable;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities.LightningStrikeStructure;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.misc.LocationStructure;
+
+import java.util.Collections;
+import java.util.List;
+
+@Action(value = "weather_strike_lightning", supportsUntil = MinecraftVersion.V1_13_2)
+@ActionDoc(
+        name = "落雷",
+        description = "ワールドに落雷を発生させます。",
+
+        executable = "ワールドに落雷を発生させます。",
+        expectable = "ワールドに落雷が発生するまで待機します。",
+        requireable = ActionDoc.UNALLOWED,
+
+        outputs = {
+                @OutputDoc(
+                        name = WeatherStrikeLightningAction.OUT_LIGHTNING,
+                        description = "落雷のエンティティです。",
+                        type = LightningStrikeStructure.class
+                )
+        }
+)
+public class WeatherStrikeLightningAction extends AbstractWeatherAction
+        implements Executable, Expectable
+{
+    public static final String OUT_LIGHTNING = "lightning";
+
+    @InputDoc(
+            name = "lightning",
+            description = "落雷のエンティティです。",
+            type = LightningStrikeStructure.class
+    )
+    public static final InputToken<LightningStrikeStructure> IN_LIGHTNING = ofInput(
+            "lightning",
+            LightningStrikeStructure.class,
+            ofDeserializer(LightningStrikeStructure.class)
+    );
+
+    @Override
+    public void execute(@NotNull ActionContext ctxt)
+    {
+        LightningStrikeStructure lightning = ctxt.input(IN_LIGHTNING);
+        Location location = this.retrieveLocation(ctxt, lightning);
+
+        if (Boolean.TRUE.equals(lightning.isEffect()))
+            location.getWorld().strikeLightningEffect(location);
+        else
+            location.getWorld().strikeLightning(location);
+    }
+
+    protected Location retrieveLocation(@NotNull ActionContext ctxt, @NotNull LightningStrikeStructure lightning)
+    {
+        LocationStructure locationStructure = lightning.getLocation();
+        if (locationStructure == null
+                || locationStructure.getX() == null || locationStructure.getY() == null || locationStructure.getZ() == null)
+            throw new IllegalActionInputException(IN_LIGHTNING, "Location(x, y, z) is not set.");
+
+        Location location;
+        // 引数に直接ワールドが指定されている場合は, それを優先
+        if (ctxt.hasInput(IN_WORLD) || ctxt.getContext().hasStage())
+        {
+            World world = super.getWorldNonNull(ctxt);
+            location = locationStructure.create(world);
+        }
+        else if (locationStructure.getWorld() != null) // それ以外の場合は, Location に設定されているワールドを使用
+            location = locationStructure.create();
+        else
+            throw new IllegalActionInputException(IN_LIGHTNING, "World is not set.");
+
+        return location;
+    }
+
+    @Override
+    public boolean checkFired(@NotNull ActionContext ctxt, @NotNull Event event)
+    {
+        if (!(event instanceof LightningStrikeEvent))
+            return false;
+        LightningStrikeEvent e = (LightningStrikeEvent) event;
+
+        boolean result = ctxt.ifHasInput(IN_LIGHTNING, lightning -> lightning.isAdequate(e.getLightning()));
+        if (result)
+            this.makeOutputs(ctxt, e);
+
+        return result;
+    }
+
+    protected void makeOutputs(@NotNull ActionContext ctxt, @NotNull LightningStrikeEvent event)
+    {
+        ctxt.output(OUT_LIGHTNING, event.getLightning());
+        super.makeOutputs(ctxt, event.getLightning().getWorld());
+    }
+
+    protected void makeOutputs(@NotNull ActionContext ctxt, @NotNull World world, @NotNull LightningStrikeStructure lightning, @Nullable LightningStrikeEvent.Cause cause)
+    {
+        ctxt.output(OUT_LIGHTNING, lightning);
+        super.makeOutputs(ctxt, world);
+    }
+
+    @Override
+    public InputBoard getInputBoard(ScenarioType type)
+    {
+        return super.getInputBoard(type)
+                .register(IN_LIGHTNING)
+                .requirePresent(IN_LIGHTNING);
+    }
+
+    @Override
+    public List<Class<? extends Event>> getAttachingEvents()
+    {
+        return Collections.singletonList(LightningStrikeEvent.class);
+    }
+}

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherChange-2.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherChange-2.yml
@@ -1,0 +1,23 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_weather_change_2
+description: Testing WeatherChangeAction without duration works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: weather_change
+    with:
+      raining: true
+  - type: expect
+    action: weather_change
+    with:
+      raining: true
+      duration: 0  # Default duration is 0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherChange.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherChange.yml
@@ -1,0 +1,24 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_weather_change
+description: Testing WeatherChangeAction works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: weather_change
+    with:
+      raining: true
+      duration: 300
+  - type: expect
+    action: weather_change
+    with:
+      raining: true
+      duration: 300

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherStrikeLightning-2.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherStrikeLightning-2.yml
@@ -1,0 +1,32 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_weather_strike_lightning_2
+description: Testing WeatherStrikeLightningAction without cause works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: weather_strike_lightning
+    with:
+      lightning:
+        location:
+          x: 0
+          y: 3
+          z: 0
+        effect: true
+  - type: expect
+    action: weather_strike_lightning
+    with:
+      lightning:
+        location:
+          x: 0
+          y: 3
+          z: 0
+        effect: true

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherStrikeLightning-3.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherStrikeLightning-3.yml
@@ -1,0 +1,25 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_weather_strike_lightning_3
+description: Testing WeatherStrikeLightningAction without lightning works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: weather_strike_lightning
+    with:
+      lightning:
+        location:
+          x: 0
+          y: 3
+          z: 0
+        effect: true
+  - type: expect
+    action: weather_strike_lightning

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherStrikeLightning-4.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherStrikeLightning-4.yml
@@ -1,0 +1,30 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_weather_strike_lightning_4
+description: Testing WeatherStrikeLightningAction without effect works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: weather_strike_lightning
+    with:
+      lightning:
+        weather:
+          x: 0
+          y: 3
+          z: 0
+  - type: expect
+    action: weather_strike_lightning
+    with:
+      lightning:
+        weather:
+          x: 0
+          y: 3
+          z: 0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherStrikeLightning-4.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherStrikeLightning-4.yml
@@ -16,7 +16,7 @@ scenario:
     action: weather_strike_lightning
     with:
       lightning:
-        weather:
+        location:
           x: 0
           y: 3
           z: 0
@@ -24,7 +24,7 @@ scenario:
     action: weather_strike_lightning
     with:
       lightning:
-        weather:
+        location:
           x: 0
           y: 3
           z: 0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherStrikeLightning.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherStrikeLightning.yml
@@ -1,0 +1,34 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+minecraft:
+  until: 1.13.2
+
+name: actions_weather_strike_lightning
+description: Testing WeatherStrikeLightningAction works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: weather_strike_lightning
+    with:
+      lightning:
+        location:
+          x: 0
+          y: 3
+          z: 0
+        effect: true
+  - type: expect
+    action: weather_strike_lightning
+    with:
+      lightning:
+        location:
+          x: 0
+          y: 3
+          z: 0
+        effect: true

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherThunderChange-2.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherThunderChange-2.yml
@@ -1,0 +1,23 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_thunder_change_2
+description: Testing ThunderChangeAction without duration works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: weather_thunder_change
+    with:
+      raining: true
+  - type: expect
+    action: weather_thunder_change
+    with:
+      raining: true
+      duration: 0  # Default duration is 0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherThunderChange-2.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherThunderChange-2.yml
@@ -1,7 +1,7 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_thunder_change_2
+name: actions_weather_thunder_change_2
 description: Testing ThunderChangeAction without duration works or not
 on:
   - type: on_load
@@ -13,11 +13,11 @@ context:
 
 scenario:
   - type: execute
-    action: weather_thunder_change
+    action: weather_change_thunder
     with:
       raining: true
   - type: expect
-    action: weather_thunder_change
+    action: weather_change_thunder
     with:
       raining: true
       duration: 0  # Default duration is 0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherThunderChange.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherThunderChange.yml
@@ -1,0 +1,24 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_thunder_change
+description: Testing WeatherThunderChangeAction works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: thunder_change
+    with:
+      thundering: true
+      duration: 300
+  - type: expect
+    action: thunder_change
+    with:
+      thundering: true
+      duration: 300

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherThunderChange.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/world/weather/WeatherThunderChange.yml
@@ -1,7 +1,7 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_thunder_change
+name: actions_weather_thunder_change
 description: Testing WeatherThunderChangeAction works or not
 on:
   - type: on_load
@@ -13,12 +13,12 @@ context:
 
 scenario:
   - type: execute
-    action: thunder_change
+    action: weather_change_thunder
     with:
       thundering: true
       duration: 300
   - type: expect
-    action: thunder_change
+    action: weather_change_thunder
     with:
       thundering: true
       duration: 300

--- a/Scenamatica/ScenamaticaActions/Extended_v1_14/src/main/java/org/kunlab/scenamatica/action/actions/extended_v1_14/world/weather/WeatherStrikeLightningAction.java
+++ b/Scenamatica/ScenamaticaActions/Extended_v1_14/src/main/java/org/kunlab/scenamatica/action/actions/extended_v1_14/world/weather/WeatherStrikeLightningAction.java
@@ -1,0 +1,112 @@
+package org.kunlab.scenamatica.action.actions.extended_v1_14.world.weather;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.event.Event;
+import org.bukkit.event.weather.LightningStrikeEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.kunlab.scenamatica.annotations.action.Action;
+import org.kunlab.scenamatica.bookkeeper.annotations.InputDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.OutputDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.OutputDocs;
+import org.kunlab.scenamatica.bookkeeper.enums.MCVersion;
+import org.kunlab.scenamatica.enums.MinecraftVersion;
+import org.kunlab.scenamatica.enums.ScenarioType;
+import org.kunlab.scenamatica.interfaces.action.ActionContext;
+import org.kunlab.scenamatica.interfaces.action.input.InputBoard;
+import org.kunlab.scenamatica.interfaces.action.input.InputToken;
+import org.kunlab.scenamatica.interfaces.action.types.Executable;
+import org.kunlab.scenamatica.interfaces.action.types.Expectable;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities.LightningStrikeStructure;
+import org.kunlab.scenamatica.nms.NMSProvider;
+import org.kunlab.scenamatica.nms.enums.entity.NMSLightningStrikeCause;
+import org.kunlab.scenamatica.nms.types.world.NMSWorldServer;
+
+import java.util.Collections;
+import java.util.List;
+
+// `cause` の追加
+
+@Action(value = "weather_strike_lightning", supportsSince = MinecraftVersion.V1_14)
+@OutputDocs({
+        @OutputDoc(
+                name = WeatherStrikeLightningAction.OUT_CAUSE,
+                description = "落雷の原因です。",
+                type = LightningStrikeEvent.Cause.class
+        )
+})
+public class WeatherStrikeLightningAction extends org.kunlab.scenamatica.action.actions.base.world.weather.WeatherStrikeLightningAction
+        implements Executable, Expectable
+{
+    public static final String OUT_CAUSE = "cause";
+
+    @InputDoc(
+            name = "cause",
+            description = "落雷の原因です。",
+            type = LightningStrikeEvent.Cause.class,
+            supportsSince = MCVersion.V1_14
+    )
+    public static final InputToken<LightningStrikeEvent.Cause> IN_CAUSE = ofInput(
+            "cause",
+            LightningStrikeEvent.Cause.class,
+            ofEnum(LightningStrikeEvent.Cause.class)
+    );
+
+    @Override
+    public void execute(@NotNull ActionContext ctxt)
+    {
+        // `cause` の追加
+        LightningStrikeEvent.Cause cause = ctxt.orElseInput(IN_CAUSE, () -> LightningStrikeEvent.Cause.UNKNOWN);
+
+        LightningStrikeStructure lightning = ctxt.input(IN_LIGHTNING);
+        boolean isEffect = Boolean.TRUE.equals(lightning.isEffect());
+        Location location = super.retrieveLocation(ctxt, lightning);
+
+        this.makeOutputs(ctxt, location.getWorld(), lightning, cause);
+        NMSWorldServer world = NMSProvider.getProvider().wrap(location.getWorld());
+        world.strikeLightning(location, isEffect, NMSLightningStrikeCause.fromBukkit(cause));
+    }
+
+    @Override
+    public boolean checkFired(@NotNull ActionContext ctxt, @NotNull Event event)
+    {
+        if (!(event instanceof LightningStrikeEvent))
+            return false;
+        LightningStrikeEvent e = (LightningStrikeEvent) event;
+
+        // `cause` の追加
+        return ctxt.ifHasInput(IN_CAUSE, cause -> cause == e.getCause())
+                && super.checkFired(ctxt, e);
+    }
+
+    @Override
+    protected void makeOutputs(@NotNull ActionContext ctxt, @NotNull LightningStrikeEvent event)
+    {
+        // `cause` の追加
+        ctxt.output(OUT_CAUSE, event.getCause());
+        super.makeOutputs(ctxt, event);
+    }
+
+    @Override
+    protected void makeOutputs(@NotNull ActionContext ctxt, @NotNull World world, @NotNull LightningStrikeStructure lightning, @Nullable LightningStrikeEvent.Cause cause)
+    {
+        // `cause` の追加
+        if (cause != null)
+            ctxt.output(OUT_CAUSE, cause);
+        super.makeOutputs(ctxt, world, lightning, cause);
+    }
+
+    @Override
+    public InputBoard getInputBoard(ScenarioType type)
+    {
+        return super.getInputBoard(type)
+                .register(IN_CAUSE);
+    }
+
+    @Override
+    public List<Class<? extends Event>> getAttachingEvents()
+    {
+        return Collections.singletonList(LightningStrikeEvent.class);
+    }
+}

--- a/Scenamatica/ScenamaticaActions/Extended_v1_14/src/main/resources/scenarios/actions/world/weather/WeatherStrikeLightning.yml
+++ b/Scenamatica/ScenamaticaActions/Extended_v1_14/src/main/resources/scenarios/actions/world/weather/WeatherStrikeLightning.yml
@@ -1,0 +1,36 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+minecraft:
+  since: 1.14.0
+
+name: actions_weather_strike_lightning
+description: Testing WeatherStrikeLightningAction works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: weather_strike_lightning
+    with:
+      lightning:
+        location:
+          x: 0
+          y: 3
+          z: 0
+        effect: true
+        cause: COMMAND
+  - type: expect
+    action: weather_strike_lightning
+    with:
+      lightning:
+        location:
+          x: 0
+          y: 3
+          z: 0
+        effect: true
+        cause: COMMAND

--- a/Scenamatica/ScenamaticaModels/src/main/java/org/kunlab/scenamatica/interfaces/structures/minecraft/entity/entities/LightningStrikeStructure.java
+++ b/Scenamatica/ScenamaticaModels/src/main/java/org/kunlab/scenamatica/interfaces/structures/minecraft/entity/entities/LightningStrikeStructure.java
@@ -1,0 +1,32 @@
+package org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities;
+
+import org.bukkit.entity.LightningStrike;
+import org.kunlab.scenamatica.bookkeeper.annotations.TypeDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.TypeProperty;
+
+/**
+ * 雷を表すインターフェースです。
+ */
+@TypeDoc(
+        name = "LightningStrike",
+        description = "雷の情報を格納します。",
+        mappingOf = LightningStrike.class,
+        properties = {
+                @TypeProperty(
+                        name = LightningStrikeStructure.KEY_EFFECT,
+                        description = "雷がダメージを与えるかどうかです。",
+                        type = boolean.class
+                )
+        }
+)
+public interface LightningStrikeStructure extends WeatherStructure
+{
+    String KEY_EFFECT = "effect";
+
+    /**
+     * 雷がダメージを与えるかどうかを取得します。
+     *
+     * @return ダメージを与えるかどうか
+     */
+    Boolean isEffect();
+}

--- a/Scenamatica/ScenamaticaModels/src/main/java/org/kunlab/scenamatica/interfaces/structures/minecraft/entity/entities/WeatherStructure.java
+++ b/Scenamatica/ScenamaticaModels/src/main/java/org/kunlab/scenamatica/interfaces/structures/minecraft/entity/entities/WeatherStructure.java
@@ -1,0 +1,10 @@
+package org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities;
+
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.EntityStructure;
+
+/**
+ * 天候を表すインターフェースです。
+ */
+public interface WeatherStructure extends EntityStructure
+{
+}

--- a/Scenamatica/ScenamaticaScenarioFile/src/main/java/org/kunlab/scenamatica/scenariofile/SelectiveEntityStructureSerializer.java
+++ b/Scenamatica/ScenamaticaScenarioFile/src/main/java/org/kunlab/scenamatica/scenariofile/SelectiveEntityStructureSerializer.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.FishHook;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LlamaSpit;
 import org.bukkit.entity.Minecart;
 import org.bukkit.entity.Player;
@@ -34,11 +35,13 @@ import org.kunlab.scenamatica.interfaces.scenariofile.StructuredYamlNode;
 import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.EntityStructure;
 import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.PlayerStructure;
 import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities.EntityItemStructure;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities.LightningStrikeStructure;
 import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities.ProjectileStructure;
 import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities.VehicleStructure;
 import org.kunlab.scenamatica.structures.minecraft.entity.EntityStructureImpl;
 import org.kunlab.scenamatica.structures.minecraft.entity.PlayerStructureImpl;
 import org.kunlab.scenamatica.structures.minecraft.entity.entities.EntityItemStructureImpl;
+import org.kunlab.scenamatica.structures.minecraft.entity.entities.LightningStrikeStructureImpl;
 import org.kunlab.scenamatica.structures.minecraft.entity.entities.ProjectileStructureImpl;
 import org.kunlab.scenamatica.structures.minecraft.entity.entities.VehicleStructureImpl;
 
@@ -88,7 +91,15 @@ public class SelectiveEntityStructureSerializer
                 PlayerStructureImpl::validatePlayer,
                 (player, ignored) -> PlayerStructureImpl.ofPlayer(player)
         );
-
+        registerStructure(
+                EntityType.LIGHTNING,
+                LightningStrikeStructure.class,
+                LightningStrike.class,
+                LightningStrikeStructureImpl::serialize,
+                LightningStrikeStructureImpl::deserialize,
+                LightningStrikeStructureImpl::validate,
+                (lightning, ignored) -> LightningStrikeStructureImpl.ofLightning(lightning)
+        );
         registerStructure(
                 EntityType.UNKNOWN,
                 EntityStructure.class,

--- a/Scenamatica/ScenamaticaStructures/src/main/java/org/kunlab/scenamatica/structures/minecraft/entity/entities/LightningStrikeStructureImpl.java
+++ b/Scenamatica/ScenamaticaStructures/src/main/java/org/kunlab/scenamatica/structures/minecraft/entity/entities/LightningStrikeStructureImpl.java
@@ -1,0 +1,132 @@
+package org.kunlab.scenamatica.structures.minecraft.entity.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LightningStrike;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.kunlab.scenamatica.enums.YAMLNodeType;
+import org.kunlab.scenamatica.exceptions.scenariofile.YamlParsingException;
+import org.kunlab.scenamatica.interfaces.scenariofile.StructureSerializer;
+import org.kunlab.scenamatica.interfaces.scenariofile.StructuredYamlNode;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.DamageStructure;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.EntityStructure;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities.LightningStrikeStructure;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.misc.LocationStructure;
+import org.kunlab.scenamatica.nms.NMSProvider;
+import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
+import org.kunlab.scenamatica.structures.minecraft.entity.EntityStructureImpl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class LightningStrikeStructureImpl extends EntityStructureImpl implements LightningStrikeStructure
+{
+    protected final Boolean effect;
+
+    public LightningStrikeStructureImpl(EntityStructure entityStructure, Boolean isEffect)
+    {
+        super(entityStructure);
+        this.effect = isEffect;
+    }
+
+    public LightningStrikeStructureImpl(@Nullable EntityType type, @NotNull EntityStructure original, Boolean effect)
+    {
+        super(type, original);
+        this.effect = effect;
+    }
+
+    public LightningStrikeStructureImpl(EntityType type, LocationStructure location, Vector velocity, String customName,
+                                        UUID uuid, Boolean glowing, Boolean gravity, Boolean silent,
+                                        Boolean customNameVisible, Boolean invulnerable, @NotNull List<String> tags,
+                                        Integer maxHealth, Integer health, DamageStructure lastDamageCause,
+                                        Integer fireTicks, Integer ticksLived, Integer portalCooldown,
+                                        Boolean persistent, Float fallDistance, Boolean effect)
+    {
+        super(
+                type, location, velocity, customName, uuid, glowing, gravity, silent, customNameVisible, invulnerable,
+                tags, maxHealth, health, lastDamageCause, fireTicks, ticksLived, portalCooldown, persistent,
+                fallDistance
+        );
+        this.effect = effect;
+    }
+
+    public LightningStrikeStructureImpl()
+    {
+        super();
+        this.effect = null;
+    }
+
+    public static LightningStrikeStructure ofLightning(@NotNull LightningStrike strike)
+    {
+        return new LightningStrikeStructureImpl(
+                EntityStructureImpl.of(strike),
+                strike.isEffect()
+        );
+    }
+
+    @NotNull
+    public static Map<String, Object> serialize(@NotNull LightningStrikeStructure structure, @NotNull StructureSerializer serializer)
+    {
+        Map<String, Object> map = EntityStructureImpl.serialize(structure, serializer);
+        map.put(LightningStrikeStructure.KEY_EFFECT, structure.isEffect());
+        return map;
+    }
+
+    public static void validate(@NotNull StructuredYamlNode node, @NotNull StructureSerializer serializer) throws YamlParsingException
+    {
+        EntityStructureImpl.validate(node);
+        node.ensureTypeOfIfExists(YAMLNodeType.BOOLEAN);
+    }
+
+    @NotNull
+    public static LightningStrikeStructure deserialize(@NotNull StructuredYamlNode node, @NotNull StructureSerializer serializer) throws YamlParsingException
+    {
+        validate(node);
+        return new LightningStrikeStructureImpl(
+                EntityStructureImpl.deserialize(node, serializer),
+                node.get(LightningStrikeStructure.KEY_EFFECT).asBoolean(null)
+        );
+    }
+
+    @Override
+    public Boolean isEffect()
+    {
+        return this.effect;
+    }
+
+    @Override
+    public boolean isAdequate(@NotNull Entity object)
+    {
+        if (!(super.isAdequate(object) && object instanceof LightningStrike))
+            return false;
+
+        LightningStrike strike = (LightningStrike) object;
+        return (this.isEffect() == null || this.isEffect().equals(strike.isEffect()));
+    }
+
+    @Override
+    public void applyTo(@NotNull Entity object)
+    {
+        super.applyTo(object);
+        LightningStrike strike = (LightningStrike) object;
+        NMSLightningStrike nmsStrike = NMSProvider.getProvider().wrap(strike);
+
+        if (this.isEffect() != null)
+            nmsStrike.setVisualOnly(this.isEffect());
+    }
+
+    @Override
+    public boolean canApplyTo(@Nullable Object target)
+    {
+        return target instanceof LightningStrike;
+    }
+}

--- a/Scenamatica/ScenamaticaStructures/src/main/java/org/kunlab/scenamatica/structures/minecraft/entity/entities/LightningStrikeStructureImpl.java
+++ b/Scenamatica/ScenamaticaStructures/src/main/java/org/kunlab/scenamatica/structures/minecraft/entity/entities/LightningStrikeStructureImpl.java
@@ -4,26 +4,20 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LightningStrike;
-import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.kunlab.scenamatica.enums.YAMLNodeType;
 import org.kunlab.scenamatica.exceptions.scenariofile.YamlParsingException;
 import org.kunlab.scenamatica.interfaces.scenariofile.StructureSerializer;
 import org.kunlab.scenamatica.interfaces.scenariofile.StructuredYamlNode;
-import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.DamageStructure;
 import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.EntityStructure;
 import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities.LightningStrikeStructure;
-import org.kunlab.scenamatica.interfaces.structures.minecraft.misc.LocationStructure;
 import org.kunlab.scenamatica.nms.NMSProvider;
 import org.kunlab.scenamatica.nms.types.entity.NMSLightningStrike;
 import org.kunlab.scenamatica.structures.minecraft.entity.EntityStructureImpl;
 
-import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 @Data
 @AllArgsConstructor
@@ -36,27 +30,6 @@ public class LightningStrikeStructureImpl extends EntityStructureImpl implements
     {
         super(entityStructure);
         this.effect = isEffect;
-    }
-
-    public LightningStrikeStructureImpl(@Nullable EntityType type, @NotNull EntityStructure original, Boolean effect)
-    {
-        super(type, original);
-        this.effect = effect;
-    }
-
-    public LightningStrikeStructureImpl(EntityType type, LocationStructure location, Vector velocity, String customName,
-                                        UUID uuid, Boolean glowing, Boolean gravity, Boolean silent,
-                                        Boolean customNameVisible, Boolean invulnerable, @NotNull List<String> tags,
-                                        Integer maxHealth, Integer health, DamageStructure lastDamageCause,
-                                        Integer fireTicks, Integer ticksLived, Integer portalCooldown,
-                                        Boolean persistent, Float fallDistance, Boolean effect)
-    {
-        super(
-                type, location, velocity, customName, uuid, glowing, gravity, silent, customNameVisible, invulnerable,
-                tags, maxHealth, health, lastDamageCause, fireTicks, ticksLived, portalCooldown, persistent,
-                fallDistance
-        );
-        this.effect = effect;
     }
 
     public LightningStrikeStructureImpl()


### PR DESCRIPTION
# feat(actions): Weather-related actions

## + Action: EX/EP `weather_change`

Burns specified block.

+ Category: `weather`
  - [`WeatherChangeEvent`](https://jd.papermc.io/paper/1.13/org/bukkit/event/weather/WeatherChangeEvent.html)

### Differences via versions

#### 1.13.2: Base implemention

+ Inputs:
  - `world` - The world to change weather
  - `raining` - Whether the world is raining or not
  - `duration` - The duration of the weather
+ Outputs:
  - `world` - The world which weather was changed
  - `raining` - Whether the world is raining or not
  - `duration` - The duration of the weather
  - 
## + Action: EX/EP `weather_change_thunder`

Burns specified block.

+ Category: `weather`
  - [`ThunderChangeEvent`](https://jd.papermc.io/paper/1.13/org/bukkit/event/weather/ThunderChangeEvent.html)

### Differences via versions

#### 1.13.2: Base implemention

+ Inputs:
  - `world` - The world to change weather
  - `thundering` - Whether the world is thundering or not
  - `duration` - The duration of the weather
+ Outputs:
  - `world` - The world which weather was changed
  - `thundering` - Whether the world is thundering or not
  - `duration` - The duration of the weather

## + Action: EX/EP `weather_strike_lightning`

Burns specified block.

+ Category: `weather`
  - [`LightningStrikeEvent`](https://jd.papermc.io/paper/1.13/org/bukkit/event/weather/LightningStrikeEvent.html)

### Differences via versions

#### 1.13.2: Base implementation

+ **Inputs**:
  - `world` - The world where the lightning strikes.
  - `lightning` - The entity representing the lightning.
+ **Outputs**:
  - `world` - The world that was struck by the lightning.
  - `lightning` - The entity representing the lightning.

#### 1.14: Arguments addition

+ **Inputs**:
  - `cause` - The cause of the lightning strike.
+ **Outputs**:
  - `cause` - The cause of the lightning strike.