### PR TITLE
# feat(actions): Typical vehicle actions

### DIFF
--- a/Scenamatica/.idea/vcs.xml
+++ b/Scenamatica/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="GitSharedSettings">
     <option name="FORCE_PUSH_PROHIBITED_PATTERNS">
       <list>

--- a/Scenamatica/NMSBridge/NMSTypes/src/main/java/org/kunlab/scenamatica/nms/types/entity/NMSDamageSource.java
+++ b/Scenamatica/NMSBridge/NMSTypes/src/main/java/org/kunlab/scenamatica/nms/types/entity/NMSDamageSource.java
@@ -1,0 +1,285 @@
+package org.kunlab.scenamatica.nms.types.entity;
+
+import javax.annotation.Nullable;
+import lombok.Getter;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Fireball;
+import org.bukkit.entity.Firework;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.WitherSkull;
+import org.bukkit.util.Vector;
+import org.kunlab.scenamatica.nms.NMSElement;
+
+/**
+ * NMSコンテキストにおけるダメージソースを表します。
+ * このインターフェースは、ダメージソースの様々なプロパティを操作およびクエリするためのメソッドを提供します。
+ */
+@Getter
+public class NMSDamageSource implements NMSElement
+{
+    public static final String ARROW_TYPE = "arrow";
+    public static final String CACTUS_TYPE = "cactus";
+    public static final String CRAMMING_TYPE = "cramming";
+    public static final String DRAGON_BREATH_TYPE = "dragonBreath";
+    public static final String DROWN_TYPE = "drown";
+    public static final String DRYOUT_TYPE = "dryout";
+    public static final String EXPLOSION_PLAYER_TYPE = "explosion.player";
+    public static final String EXPLOSION_TYPE = "explosion";
+    public static final String FALL_TYPE = "fall";
+    public static final String FALLING_BLOCK_TYPE = "fallingBlock";
+    public static final String FALLING_STALACTITE_TYPE = "fallingStalactite";
+    public static final String FIREBALL_TYPE = "fireball";
+    public static final String FIREWORKS_TYPE = "fireworks";
+    public static final String FLY_INTO_WALL_TYPE = "flyIntoWall";
+    public static final String FREEZE_TYPE = "freeze";
+    public static final String GENERIC_TYPE = "generic";
+    public static final String HOT_FLOOR_TYPE = "hotFloor";
+    public static final String IN_FIRE_TYPE = "inFire";
+    public static final String IN_WALL_TYPE = "inWall";
+    public static final String INDIRECT_MAGIC_TYPE = "indirectMagic";
+    public static final String LAVA_TYPE = "lava";
+    public static final String LIGHTNING_BOLT_TYPE = "lightningBolt";
+    public static final String MAGIC_TYPE = "magic";
+    public static final String MOB_TYPE = "mob";
+    public static final String ON_FIRE_TYPE = "onFire";
+    public static final String OUT_OF_WORLD_TYPE = "outOfWorld";
+    public static final String PLAYER_TYPE = "player";
+    public static final String STALAGMITE_TYPE = "stalagmite";
+    public static final String STARVE_TYPE = "starve";
+    public static final String STING_TYPE = "sting";
+    public static final String SWEET_BERRY_BUSH_TYPE = "sweetBerryBush";
+    public static final String THORNS_TYPE = "thorns";
+    public static final String THROWN_TYPE = "thrown";
+    public static final String TRIDENT_TYPE = "trident";
+    public static final String WITHER_SKULL_TYPE = "witherSkull";
+    public static final String WITHER_TYPE = "wither";
+
+    public static final NMSDamageSource CACTUS = new NMSDamageSource(CACTUS_TYPE);
+    public static final NMSDamageSource CRAMMING = new NMSDamageSource(CRAMMING_TYPE);
+    public static final NMSDamageSource DRAGON_BREATH = new NMSDamageSource(DRAGON_BREATH_TYPE).bypassArmor().bypassMagic();
+    public static final NMSDamageSource DROWN = new NMSDamageSource(DROWN_TYPE);
+    public static final NMSDamageSource DRYOUT = new NMSDamageSource(DRYOUT_TYPE);
+    public static final NMSDamageSource FALL = new NMSDamageSource(FALL_TYPE).isFall();
+    public static final NMSDamageSource FALLING_BLOCK = new NMSDamageSource(FALLING_BLOCK_TYPE);
+    public static final NMSDamageSource FALLING_STALACTITE = new NMSDamageSource(FALLING_STALACTITE_TYPE).isFall();
+    public static final NMSDamageSource FLY_INTO_WALL = new NMSDamageSource(FLY_INTO_WALL_TYPE);
+    public static final NMSDamageSource FREEZE = new NMSDamageSource(FREEZE_TYPE).bypassArmor().bypassMagic();
+    public static final NMSDamageSource GENERIC = new NMSDamageSource(GENERIC_TYPE);
+    public static final NMSDamageSource HOT_FLOOR = new NMSDamageSource(HOT_FLOOR_TYPE).isFire();
+    public static final NMSDamageSource IN_FIRE = new NMSDamageSource(IN_FIRE_TYPE).isFire();
+    public static final NMSDamageSource IN_WALL = new NMSDamageSource(IN_WALL_TYPE);
+    public static final NMSDamageSource LAVA = new NMSDamageSource(LAVA_TYPE).isFire();
+    public static final NMSDamageSource LIGHTNING_BOLT = new NMSDamageSource(LIGHTNING_BOLT_TYPE);
+    public static final NMSDamageSource MAGIC = new NMSDamageSource(MAGIC_TYPE).bypassArmor().bypassMagic();
+    public static final NMSDamageSource ON_FIRE = new NMSDamageSource(ON_FIRE_TYPE).isFire();
+    public static final NMSDamageSource OUT_OF_WORLD = new NMSDamageSource(OUT_OF_WORLD_TYPE).bypassArmor().bypassInvul();
+    public static final NMSDamageSource STALAGMITE = new NMSDamageSource(STALAGMITE_TYPE).isFall();
+    public static final NMSDamageSource STARVE = new NMSDamageSource(STARVE_TYPE).bypassArmor().bypassMagic();
+    public static final NMSDamageSource SWEET_BERRY_BUSH = new NMSDamageSource(SWEET_BERRY_BUSH_TYPE);
+    public static final NMSDamageSource WITHER = new NMSDamageSource(WITHER_TYPE).bypassArmor().bypassMagic();
+
+    private final String damageType;
+
+    private boolean damageHelmet;
+    private boolean bypassArmor;
+    private boolean bypassInvul;
+    private boolean bypassMagic;
+    private float exhaustion = 0.1F;
+    private boolean isFireSource;
+    private boolean isProjectile;
+    private boolean scalesWithDifficulty;
+    private boolean isMagic;
+    private boolean isExplosion;
+    private boolean isFall;
+    private boolean noAggro;
+    private Entity directEntity;
+    private Entity entity;
+    private Vector sourcePosition;
+
+    public NMSDamageSource(String damageType)
+    {
+        this.damageType = damageType;
+    }
+
+    public static NMSDamageSource arrow(Arrow arrow, @Nullable Entity shooter)
+    {
+        return new NMSDamageSource(ARROW_TYPE).entity(arrow).directEntity(shooter).projectile();
+    }
+
+    public static NMSDamageSource explosion(@Nullable LivingEntity entity)
+    {
+        return entity != null ? new NMSDamageSource(EXPLOSION_PLAYER_TYPE).entity(entity).scalesWithDifficulty().explosion(): new NMSDamageSource(EXPLOSION_TYPE).scalesWithDifficulty().explosion();
+    }
+
+    public static NMSDamageSource fireball(Fireball fireball, @Nullable Entity shooter)
+    {
+        return new NMSDamageSource(FIREBALL_TYPE).entity(fireball).directEntity(shooter).isFire().projectile();
+    }
+
+    public static NMSDamageSource fireworks(Firework firework, @Nullable Entity shooter)
+    {
+        return new NMSDamageSource(FIREWORKS_TYPE).entity(firework).directEntity(shooter).explosion();
+    }
+
+    public static NMSDamageSource indirectMagic(Entity magic, @Nullable Entity shooter)
+    {
+        return new NMSDamageSource(INDIRECT_MAGIC_TYPE).entity(magic).directEntity(shooter).bypassArmor().magic();
+    }
+
+    public static NMSDamageSource indirectMobAttack(Entity entity, @Nullable LivingEntity indirectEntity)
+    {
+        return new NMSDamageSource(MOB_TYPE).entity(entity).directEntity(indirectEntity);
+    }
+
+    public static NMSDamageSource mobAttack(LivingEntity entity)
+    {
+        return new NMSDamageSource(MOB_TYPE).entity(entity);
+    }
+
+    public static NMSDamageSource playerAttack(Player player)
+    {
+        return new NMSDamageSource(PLAYER_TYPE).entity(player);
+    }
+
+    public static NMSDamageSource anyEntityAttack(Entity entity)
+    {
+        if (entity instanceof HumanEntity)
+            return playerAttack((Player) entity);
+        else if (entity instanceof LivingEntity)
+            return mobAttack((LivingEntity) entity);
+        else
+            return new NMSDamageSource(GENERIC_TYPE).entity(entity);
+    }
+
+    public static NMSDamageSource sting(LivingEntity entity)
+    {
+        return new NMSDamageSource(STING_TYPE).entity(entity);
+    }
+
+    public static NMSDamageSource thorns(Entity entity)
+    {
+        return new NMSDamageSource(THORNS_TYPE).entity(entity).magic();
+    }
+
+    public static NMSDamageSource thrown(Entity thrown, @Nullable Entity shooter)
+    {
+        return new NMSDamageSource(THROWN_TYPE).entity(thrown).directEntity(shooter).projectile();
+    }
+
+    public static NMSDamageSource trident(Entity trident, @Nullable Entity shooter)
+    {
+        return new NMSDamageSource(TRIDENT_TYPE).entity(trident).directEntity(shooter).projectile();
+    }
+
+    public static NMSDamageSource witherSkull(WitherSkull witherSkull, Entity shooter)
+    {
+        return new NMSDamageSource(WITHER_SKULL_TYPE).entity(witherSkull).directEntity(shooter).projectile();
+    }
+
+    public NMSDamageSource damageHelmet()
+    {
+        this.damageHelmet = true;
+        return this;
+    }
+
+    public NMSDamageSource bypassArmor()
+    {
+        this.bypassArmor = true;
+        this.exhaustion = 0.0F;
+        return this;
+    }
+
+    public NMSDamageSource bypassInvul()
+    {
+        this.bypassInvul = true;
+        return this;
+    }
+
+    public NMSDamageSource bypassMagic()
+    {
+        this.bypassMagic = true;
+        this.exhaustion = 0.0F;
+        return this;
+    }
+
+    public NMSDamageSource isFire()
+    {
+        this.isFireSource = true;
+        return this;
+    }
+
+    public NMSDamageSource projectile()
+    {
+        this.isProjectile = true;
+        return this;
+    }
+
+    public NMSDamageSource explosion()
+    {
+        this.isExplosion = true;
+        return this;
+    }
+
+    public NMSDamageSource isFall()
+    {
+        this.isFall = true;
+        return this;
+    }
+
+    public NMSDamageSource noAggro()
+    {
+        this.noAggro = true;
+        return this;
+    }
+
+    public NMSDamageSource scalesWithDifficulty()
+    {
+        this.scalesWithDifficulty = true;
+        return this;
+    }
+
+    public NMSDamageSource magic()
+    {
+        this.isMagic = true;
+        return this;
+    }
+
+    public NMSDamageSource directEntity(Entity directEntity)
+    {
+        this.directEntity = directEntity;
+        return this;
+    }
+
+    public NMSDamageSource entity(Entity entity)
+    {
+        this.entity = entity;
+        return this;
+    }
+
+    public NMSDamageSource sourcePosition(Vector sourcePosition)
+    {
+        this.sourcePosition = sourcePosition;
+        return this;
+    }
+
+    @Nullable
+    public Entity getDirectEntity()
+    {
+        return this.directEntity;
+    }
+
+    @Nullable
+    public Entity getEntity()
+    {
+        return this.entity;
+    }
+
+    @Nullable
+    public Vector getSourcePosition()
+    {
+        return this.sourcePosition;
+    }
+}

--- a/Scenamatica/NMSBridge/NMSTypes/src/main/java/org/kunlab/scenamatica/nms/types/entity/NMSEntity.java
+++ b/Scenamatica/NMSBridge/NMSTypes/src/main/java/org/kunlab/scenamatica/nms/types/entity/NMSEntity.java
@@ -37,6 +37,16 @@ public interface NMSEntity extends NMSWrapped
     NMSEntityItem dropItem(@NotNull NMSItemStack stack, float offsetY);
 
     /**
+     * エンティティにダメージを与えます。
+     * a.k.a. <code>Entity#hurt(DamageSource, float)</code>
+     *
+     * @param source ダメージのソース
+     * @param damage ダメージ量
+     * @return ダメージを受けたかどうか
+     */
+    boolean damageEntity(NMSDamageSource source, float damage);
+
+    /**
      * エンティティが非表示かどうかを取得します。
      *
      * @return 非表示かどうか

--- a/Scenamatica/NMSBridge/v1_13_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R1/entity/NMSEntityImpl.java
+++ b/Scenamatica/NMSBridge/v1_13_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R1/entity/NMSEntityImpl.java
@@ -10,6 +10,8 @@ import org.bukkit.craftbukkit.v1_13_R1.entity.CraftEntity;
 import org.jetbrains.annotations.NotNull;
 import org.kunlab.scenamatica.nms.enums.entity.NMSMoveType;
 import org.kunlab.scenamatica.nms.impl.v1_13_R1.TypeSupportImpl;
+import org.kunlab.scenamatica.nms.impl.v1_13_R1.utils.DamageSourceSupport;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntity;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
@@ -114,6 +116,15 @@ public class NMSEntityImpl implements NMSEntity
 
 
         return new NMSEntityItemImpl(dropped);
+    }
+
+    @Override
+    public boolean damageEntity(NMSDamageSource source, float damage)
+    {
+        return this.nmsEntity.damageEntity(
+                DamageSourceSupport.fromNMSDamageSource(source),
+                damage
+        );
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_13_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R1/utils/DamageSourceSupport.java
+++ b/Scenamatica/NMSBridge/v1_13_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R1/utils/DamageSourceSupport.java
@@ -1,0 +1,109 @@
+package org.kunlab.scenamatica.nms.impl.v1_13_R1.utils;
+
+import net.minecraft.server.v1_13_R1.DamageSource;
+import net.minecraft.server.v1_13_R1.Entity;
+import net.minecraft.server.v1_13_R1.EntityArrow;
+import net.minecraft.server.v1_13_R1.EntityFireball;
+import net.minecraft.server.v1_13_R1.EntityHuman;
+import net.minecraft.server.v1_13_R1.EntityLiving;
+import org.bukkit.craftbukkit.v1_13_R1.entity.CraftEntity;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
+
+public class DamageSourceSupport
+{
+    public static DamageSource fromNMSDamageSource(NMSDamageSource source)
+    {
+        switch (source.getDamageType())
+        {
+            case NMSDamageSource.ARROW_TYPE:
+                return DamageSource.arrow(
+                        convertEntity(source.getEntity(), EntityArrow.class, org.bukkit.entity.Arrow.class),
+                        convertEntity(source.getDirectEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.CACTUS_TYPE:
+                return DamageSource.CACTUS;
+            case NMSDamageSource.CRAMMING_TYPE:
+                return DamageSource.CRAMMING;
+            case NMSDamageSource.DRAGON_BREATH_TYPE:
+                return DamageSource.DRAGON_BREATH;
+            case NMSDamageSource.DROWN_TYPE:
+                return DamageSource.DROWN;
+            case NMSDamageSource.DRYOUT_TYPE:
+                return DamageSource.DRYOUT;
+            case NMSDamageSource.EXPLOSION_TYPE:
+            case NMSDamageSource.EXPLOSION_PLAYER_TYPE:
+                return DamageSource.b(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FALL_TYPE:
+                return DamageSource.FALL;
+            case NMSDamageSource.FALLING_BLOCK_TYPE:
+                return DamageSource.FALLING_BLOCK;
+            case NMSDamageSource.FIREBALL_TYPE:
+                return DamageSource.fireball(
+                        convertEntity(source.getEntity(), EntityFireball.class, org.bukkit.entity.Fireball.class),
+                        convertEntity(source.getDirectEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FIREWORKS_TYPE:
+                return DamageSource.FIREWORKS;
+            case NMSDamageSource.FLY_INTO_WALL_TYPE:
+                return DamageSource.FLY_INTO_WALL;
+            case NMSDamageSource.GENERIC_TYPE:
+                return DamageSource.GENERIC;
+            case NMSDamageSource.HOT_FLOOR_TYPE:
+                return DamageSource.HOT_FLOOR;
+            case NMSDamageSource.IN_FIRE_TYPE:
+                return DamageSource.FIRE;
+            case NMSDamageSource.IN_WALL_TYPE:
+                return DamageSource.STUCK;
+            case NMSDamageSource.LAVA_TYPE:
+                return DamageSource.LAVA;
+            case NMSDamageSource.LIGHTNING_BOLT_TYPE:
+                return DamageSource.LIGHTNING;
+            case NMSDamageSource.MAGIC_TYPE:
+                return DamageSource.MAGIC;
+            case NMSDamageSource.MOB_TYPE:
+                return DamageSource.mobAttack(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.ON_FIRE_TYPE:
+                return DamageSource.BURN;
+            case NMSDamageSource.OUT_OF_WORLD_TYPE:
+                return DamageSource.OUT_OF_WORLD;
+            case NMSDamageSource.PLAYER_TYPE:
+                return DamageSource.playerAttack(
+                        convertEntity(source.getEntity(), EntityHuman.class, org.bukkit.entity.Player.class)
+                );
+            case NMSDamageSource.STARVE_TYPE:
+                return DamageSource.STARVE;
+            case NMSDamageSource.THORNS_TYPE:
+                return DamageSource.a(convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.LivingEntity.class));
+            case NMSDamageSource.INDIRECT_MAGIC_TYPE:
+                return DamageSource.c(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.THROWN_TYPE:
+                return DamageSource.projectile(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.TRIDENT_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Trident.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.WITHER_TYPE:
+                return DamageSource.WITHER;
+            default:
+                throw new IllegalArgumentException("Unknown damage type: " + source.getDamageType());
+        }
+    }
+
+    private static <T extends Entity> T convertEntity(org.bukkit.entity.Entity entity, Class<T> nmsClazz, Class<? extends org.bukkit.entity.Entity> bukkitClazz)
+    {
+        if (!bukkitClazz.isInstance(entity))
+            throw new IllegalArgumentException("Entity is not an instance of " + bukkitClazz.getName());
+        return nmsClazz.cast(((CraftEntity) entity).getHandle());
+    }
+}

--- a/Scenamatica/NMSBridge/v1_13_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R2/entity/NMSEntityImpl.java
+++ b/Scenamatica/NMSBridge/v1_13_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R2/entity/NMSEntityImpl.java
@@ -10,6 +10,8 @@ import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
 import org.jetbrains.annotations.NotNull;
 import org.kunlab.scenamatica.nms.enums.entity.NMSMoveType;
 import org.kunlab.scenamatica.nms.impl.v1_13_R2.TypeSupportImpl;
+import org.kunlab.scenamatica.nms.impl.v1_13_R2.utils.DamageSourceSupport;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntity;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
@@ -115,6 +117,16 @@ public class NMSEntityImpl implements NMSEntity
 
         return new NMSEntityItemImpl(dropped);
     }
+
+    @Override
+    public boolean damageEntity(NMSDamageSource source, float damage)
+    {
+        return this.nmsEntity.damageEntity(
+                DamageSourceSupport.fromNMSDamageSource(source),
+                damage
+        );
+    }
+
 
     @Override
     public boolean isInvisible()

--- a/Scenamatica/NMSBridge/v1_13_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R2/utils/DamageSourceSupport.java
+++ b/Scenamatica/NMSBridge/v1_13_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_13_R2/utils/DamageSourceSupport.java
@@ -1,0 +1,109 @@
+package org.kunlab.scenamatica.nms.impl.v1_13_R2.utils;
+
+import net.minecraft.server.v1_13_R2.DamageSource;
+import net.minecraft.server.v1_13_R2.Entity;
+import net.minecraft.server.v1_13_R2.EntityArrow;
+import net.minecraft.server.v1_13_R2.EntityFireball;
+import net.minecraft.server.v1_13_R2.EntityHuman;
+import net.minecraft.server.v1_13_R2.EntityLiving;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
+
+public class DamageSourceSupport
+{
+    public static DamageSource fromNMSDamageSource(NMSDamageSource source)
+    {
+        switch (source.getDamageType())
+        {
+            case NMSDamageSource.ARROW_TYPE:
+                return DamageSource.arrow(
+                        convertEntity(source.getEntity(), EntityArrow.class, org.bukkit.entity.Arrow.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.CACTUS_TYPE:
+                return DamageSource.CACTUS;
+            case NMSDamageSource.CRAMMING_TYPE:
+                return DamageSource.CRAMMING;
+            case NMSDamageSource.DRAGON_BREATH_TYPE:
+                return DamageSource.DRAGON_BREATH;
+            case NMSDamageSource.DROWN_TYPE:
+                return DamageSource.DROWN;
+            case NMSDamageSource.DRYOUT_TYPE:
+                return DamageSource.DRYOUT;
+            case NMSDamageSource.EXPLOSION_TYPE:
+            case NMSDamageSource.EXPLOSION_PLAYER_TYPE:
+                return DamageSource.b(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FALL_TYPE:
+                return DamageSource.FALL;
+            case NMSDamageSource.FALLING_BLOCK_TYPE:
+                return DamageSource.FALLING_BLOCK;
+            case NMSDamageSource.FIREBALL_TYPE:
+                return DamageSource.fireball(
+                        convertEntity(source.getEntity(), EntityFireball.class, org.bukkit.entity.Fireball.class),
+                        convertEntity(source.getDirectEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FIREWORKS_TYPE:
+                return DamageSource.FIREWORKS;
+            case NMSDamageSource.FLY_INTO_WALL_TYPE:
+                return DamageSource.FLY_INTO_WALL;
+            case NMSDamageSource.GENERIC_TYPE:
+                return DamageSource.GENERIC;
+            case NMSDamageSource.HOT_FLOOR_TYPE:
+                return DamageSource.HOT_FLOOR;
+            case NMSDamageSource.IN_FIRE_TYPE:
+                return DamageSource.FIRE;
+            case NMSDamageSource.IN_WALL_TYPE:
+                return DamageSource.STUCK;
+            case NMSDamageSource.LAVA_TYPE:
+                return DamageSource.LAVA;
+            case NMSDamageSource.LIGHTNING_BOLT_TYPE:
+                return DamageSource.LIGHTNING;
+            case NMSDamageSource.MAGIC_TYPE:
+                return DamageSource.MAGIC;
+            case NMSDamageSource.MOB_TYPE:
+                return DamageSource.mobAttack(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.ON_FIRE_TYPE:
+                return DamageSource.BURN;
+            case NMSDamageSource.OUT_OF_WORLD_TYPE:
+                return DamageSource.OUT_OF_WORLD;
+            case NMSDamageSource.PLAYER_TYPE:
+                return DamageSource.playerAttack(
+                        convertEntity(source.getEntity(), EntityHuman.class, org.bukkit.entity.Player.class)
+                );
+            case NMSDamageSource.STARVE_TYPE:
+                return DamageSource.STARVE;
+            case NMSDamageSource.THORNS_TYPE:
+                return DamageSource.a(convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.LivingEntity.class));
+            case NMSDamageSource.INDIRECT_MAGIC_TYPE:
+                return DamageSource.c(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.THROWN_TYPE:
+                return DamageSource.projectile(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.TRIDENT_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Trident.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.WITHER_TYPE:
+                return DamageSource.WITHER;
+            default:
+                throw new IllegalArgumentException("Unknown damage type: " + source.getDamageType());
+        }
+    }
+
+    private static <T extends Entity> T convertEntity(org.bukkit.entity.Entity entity, Class<T> nmsClazz, Class<? extends org.bukkit.entity.Entity> bukkitClazz)
+    {
+        if (!bukkitClazz.isInstance(entity))
+            throw new IllegalArgumentException("Entity is not an instance of " + bukkitClazz.getName());
+        return nmsClazz.cast(((CraftEntity) entity).getHandle());
+    }
+}

--- a/Scenamatica/NMSBridge/v1_14_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_14_R1/entity/NMSEntityImpl.java
+++ b/Scenamatica/NMSBridge/v1_14_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_14_R1/entity/NMSEntityImpl.java
@@ -11,6 +11,8 @@ import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
 import org.jetbrains.annotations.NotNull;
 import org.kunlab.scenamatica.nms.enums.entity.NMSMoveType;
 import org.kunlab.scenamatica.nms.impl.v1_14_R1.TypeSupportImpl;
+import org.kunlab.scenamatica.nms.impl.v1_14_R1.utils.DamageSourceSupport;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntity;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
@@ -113,6 +115,15 @@ public class NMSEntityImpl implements NMSEntity
 
 
         return new NMSEntityItemImpl(dropped);
+    }
+
+    @Override
+    public boolean damageEntity(NMSDamageSource source, float damage)
+    {
+        return this.nmsEntity.damageEntity(
+                DamageSourceSupport.fromNMSDamageSource(source),
+                damage
+        );
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_14_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_14_R1/utils/DamageSourceSupport.java
+++ b/Scenamatica/NMSBridge/v1_14_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_14_R1/utils/DamageSourceSupport.java
@@ -1,0 +1,111 @@
+package org.kunlab.scenamatica.nms.impl.v1_14_R1.utils;
+
+import net.minecraft.server.v1_14_R1.DamageSource;
+import net.minecraft.server.v1_14_R1.Entity;
+import net.minecraft.server.v1_14_R1.EntityArrow;
+import net.minecraft.server.v1_14_R1.EntityFireballFireball;
+import net.minecraft.server.v1_14_R1.EntityHuman;
+import net.minecraft.server.v1_14_R1.EntityLiving;
+import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
+
+public class DamageSourceSupport
+{
+    public static DamageSource fromNMSDamageSource(NMSDamageSource source)
+    {
+        switch (source.getDamageType())
+        {
+            case NMSDamageSource.ARROW_TYPE:
+                return DamageSource.arrow(
+                        convertEntity(source.getEntity(), EntityArrow.class, org.bukkit.entity.Arrow.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.CACTUS_TYPE:
+                return DamageSource.CACTUS;
+            case NMSDamageSource.CRAMMING_TYPE:
+                return DamageSource.CRAMMING;
+            case NMSDamageSource.DRAGON_BREATH_TYPE:
+                return DamageSource.DRAGON_BREATH;
+            case NMSDamageSource.DROWN_TYPE:
+                return DamageSource.DROWN;
+            case NMSDamageSource.DRYOUT_TYPE:
+                return DamageSource.DRYOUT;
+            case NMSDamageSource.EXPLOSION_TYPE:
+            case NMSDamageSource.EXPLOSION_PLAYER_TYPE:
+                return DamageSource.b(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FALL_TYPE:
+                return DamageSource.FALL;
+            case NMSDamageSource.FALLING_BLOCK_TYPE:
+                return DamageSource.FALLING_BLOCK;
+            case NMSDamageSource.FIREBALL_TYPE:
+                return DamageSource.fireball(
+                        convertEntity(source.getEntity(), EntityFireballFireball.class, org.bukkit.entity.Fireball.class),
+                        convertEntity(source.getDirectEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FIREWORKS_TYPE:
+                return DamageSource.FIREWORKS;
+            case NMSDamageSource.FLY_INTO_WALL_TYPE:
+                return DamageSource.FLY_INTO_WALL;
+            case NMSDamageSource.GENERIC_TYPE:
+                return DamageSource.GENERIC;
+            case NMSDamageSource.HOT_FLOOR_TYPE:
+                return DamageSource.HOT_FLOOR;
+            case NMSDamageSource.IN_FIRE_TYPE:
+                return DamageSource.FIRE;
+            case NMSDamageSource.IN_WALL_TYPE:
+                return DamageSource.STUCK;
+            case NMSDamageSource.LAVA_TYPE:
+                return DamageSource.LAVA;
+            case NMSDamageSource.LIGHTNING_BOLT_TYPE:
+                return DamageSource.LIGHTNING;
+            case NMSDamageSource.MAGIC_TYPE:
+                return DamageSource.MAGIC;
+            case NMSDamageSource.MOB_TYPE:
+                return DamageSource.mobAttack(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.ON_FIRE_TYPE:
+                return DamageSource.BURN;
+            case NMSDamageSource.OUT_OF_WORLD_TYPE:
+                return DamageSource.OUT_OF_WORLD;
+            case NMSDamageSource.PLAYER_TYPE:
+                return DamageSource.playerAttack(
+                        convertEntity(source.getEntity(), EntityHuman.class, org.bukkit.entity.Player.class)
+                );
+            case NMSDamageSource.STARVE_TYPE:
+                return DamageSource.STARVE;
+            case NMSDamageSource.SWEET_BERRY_BUSH_TYPE:
+                return DamageSource.SWEET_BERRY_BUSH;
+            case NMSDamageSource.THORNS_TYPE:
+                return DamageSource.a(convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.LivingEntity.class));
+            case NMSDamageSource.INDIRECT_MAGIC_TYPE:
+                return DamageSource.c(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.THROWN_TYPE:
+                return DamageSource.projectile(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.TRIDENT_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Trident.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.WITHER_TYPE:
+                return DamageSource.WITHER;
+            default:
+                throw new IllegalArgumentException("Unknown damage type: " + source.getDamageType());
+        }
+    }
+
+    private static <T extends Entity> T convertEntity(org.bukkit.entity.Entity entity, Class<T> nmsClazz, Class<? extends org.bukkit.entity.Entity> bukkitClazz)
+    {
+        if (!bukkitClazz.isInstance(entity))
+            throw new IllegalArgumentException("Entity is not an instance of " + bukkitClazz.getName());
+        return nmsClazz.cast(((CraftEntity) entity).getHandle());
+    }
+}

--- a/Scenamatica/NMSBridge/v1_15_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_15_R1/entity/NMSEntityImpl.java
+++ b/Scenamatica/NMSBridge/v1_15_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_15_R1/entity/NMSEntityImpl.java
@@ -11,7 +11,9 @@ import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.jetbrains.annotations.NotNull;
 import org.kunlab.scenamatica.nms.enums.entity.NMSMoveType;
 import org.kunlab.scenamatica.nms.impl.v1_15_R1.TypeSupportImpl;
+import org.kunlab.scenamatica.nms.impl.v1_15_R1.utils.DamageSourceSupport;
 import org.kunlab.scenamatica.nms.impl.v1_15_R1.utils.NMSSupport;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntity;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
@@ -111,6 +113,15 @@ public class NMSEntityImpl implements NMSEntity
             return null;
 
         return new NMSEntityItemImpl(dropped);
+    }
+
+    @Override
+    public boolean damageEntity(NMSDamageSource source, float damage)
+    {
+        return this.nmsEntity.damageEntity(
+                DamageSourceSupport.fromNMSDamageSource(source),
+                damage
+        );
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_15_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_15_R1/utils/DamageSourceSupport.java
+++ b/Scenamatica/NMSBridge/v1_15_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_15_R1/utils/DamageSourceSupport.java
@@ -1,0 +1,115 @@
+package org.kunlab.scenamatica.nms.impl.v1_15_R1.utils;
+
+import net.minecraft.server.v1_15_R1.DamageSource;
+import net.minecraft.server.v1_15_R1.Entity;
+import net.minecraft.server.v1_15_R1.EntityArrow;
+import net.minecraft.server.v1_15_R1.EntityFireballFireball;
+import net.minecraft.server.v1_15_R1.EntityHuman;
+import net.minecraft.server.v1_15_R1.EntityLiving;
+import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
+
+public class DamageSourceSupport
+{
+    public static DamageSource fromNMSDamageSource(NMSDamageSource source)
+    {
+        switch (source.getDamageType())
+        {
+            case NMSDamageSource.ARROW_TYPE:
+                return DamageSource.arrow(
+                        convertEntity(source.getEntity(), EntityArrow.class, org.bukkit.entity.Arrow.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.CACTUS_TYPE:
+                return DamageSource.CACTUS;
+            case NMSDamageSource.CRAMMING_TYPE:
+                return DamageSource.CRAMMING;
+            case NMSDamageSource.DRAGON_BREATH_TYPE:
+                return DamageSource.DRAGON_BREATH;
+            case NMSDamageSource.DROWN_TYPE:
+                return DamageSource.DROWN;
+            case NMSDamageSource.DRYOUT_TYPE:
+                return DamageSource.DRYOUT;
+            case NMSDamageSource.EXPLOSION_TYPE:
+            case NMSDamageSource.EXPLOSION_PLAYER_TYPE:
+                return DamageSource.c(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FALL_TYPE:
+                return DamageSource.FALL;
+            case NMSDamageSource.FALLING_BLOCK_TYPE:
+                return DamageSource.FALLING_BLOCK;
+            case NMSDamageSource.FIREBALL_TYPE:
+                return DamageSource.fireball(
+                        convertEntity(source.getEntity(), EntityFireballFireball.class, org.bukkit.entity.Fireball.class),
+                        convertEntity(source.getDirectEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FIREWORKS_TYPE:
+                return DamageSource.FIREWORKS;
+            case NMSDamageSource.FLY_INTO_WALL_TYPE:
+                return DamageSource.FLY_INTO_WALL;
+            case NMSDamageSource.GENERIC_TYPE:
+                return DamageSource.GENERIC;
+            case NMSDamageSource.HOT_FLOOR_TYPE:
+                return DamageSource.HOT_FLOOR;
+            case NMSDamageSource.IN_FIRE_TYPE:
+                return DamageSource.FIRE;
+            case NMSDamageSource.IN_WALL_TYPE:
+                return DamageSource.STUCK;
+            case NMSDamageSource.LAVA_TYPE:
+                return DamageSource.LAVA;
+            case NMSDamageSource.LIGHTNING_BOLT_TYPE:
+                return DamageSource.LIGHTNING;
+            case NMSDamageSource.MAGIC_TYPE:
+                return DamageSource.MAGIC;
+            case NMSDamageSource.MOB_TYPE:
+                return DamageSource.mobAttack(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.ON_FIRE_TYPE:
+                return DamageSource.BURN;
+            case NMSDamageSource.OUT_OF_WORLD_TYPE:
+                return DamageSource.OUT_OF_WORLD;
+            case NMSDamageSource.PLAYER_TYPE:
+                return DamageSource.playerAttack(
+                        convertEntity(source.getEntity(), EntityHuman.class, org.bukkit.entity.Player.class)
+                );
+            case NMSDamageSource.STARVE_TYPE:
+                return DamageSource.STARVE;
+            case NMSDamageSource.STING_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.SWEET_BERRY_BUSH_TYPE:
+                return DamageSource.SWEET_BERRY_BUSH;
+            case NMSDamageSource.THORNS_TYPE:
+                return DamageSource.a(convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.LivingEntity.class));
+            case NMSDamageSource.INDIRECT_MAGIC_TYPE:
+                return DamageSource.c(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.THROWN_TYPE:
+                return DamageSource.projectile(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.TRIDENT_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Trident.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.WITHER_TYPE:
+                return DamageSource.WITHER;
+            default:
+                throw new IllegalArgumentException("Unknown damage type: " + source.getDamageType());
+        }
+    }
+
+    private static <T extends Entity> T convertEntity(org.bukkit.entity.Entity entity, Class<T> nmsClazz, Class<? extends org.bukkit.entity.Entity> bukkitClazz)
+    {
+        if (!bukkitClazz.isInstance(entity))
+            throw new IllegalArgumentException("Entity is not an instance of " + bukkitClazz.getName());
+        return nmsClazz.cast(((CraftEntity) entity).getHandle());
+    }
+}

--- a/Scenamatica/NMSBridge/v1_16_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R1/entity/NMSEntityImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R1/entity/NMSEntityImpl.java
@@ -11,7 +11,9 @@ import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.jetbrains.annotations.NotNull;
 import org.kunlab.scenamatica.nms.enums.entity.NMSMoveType;
 import org.kunlab.scenamatica.nms.impl.v1_16_R1.TypeSupportImpl;
+import org.kunlab.scenamatica.nms.impl.v1_16_R1.utils.DamageSourceSupport;
 import org.kunlab.scenamatica.nms.impl.v1_16_R1.utils.NMSSupport;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntity;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
@@ -111,6 +113,15 @@ public class NMSEntityImpl implements NMSEntity
             return null;
 
         return new NMSEntityItemImpl(dropped);
+    }
+
+    @Override
+    public boolean damageEntity(NMSDamageSource source, float damage)
+    {
+        return this.nmsEntity.damageEntity(
+                DamageSourceSupport.fromNMSDamageSource(source),
+                damage
+        );
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_16_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R1/utils/DamageSourceSupport.java
+++ b/Scenamatica/NMSBridge/v1_16_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R1/utils/DamageSourceSupport.java
@@ -1,0 +1,126 @@
+package org.kunlab.scenamatica.nms.impl.v1_16_R1.utils;
+
+import net.minecraft.server.v1_16_R1.DamageSource;
+import net.minecraft.server.v1_16_R1.Entity;
+import net.minecraft.server.v1_16_R1.EntityArrow;
+import net.minecraft.server.v1_16_R1.EntityFireballFireball;
+import net.minecraft.server.v1_16_R1.EntityFireworks;
+import net.minecraft.server.v1_16_R1.EntityHuman;
+import net.minecraft.server.v1_16_R1.EntityLiving;
+import net.minecraft.server.v1_16_R1.EntityWitherSkull;
+import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
+import org.bukkit.entity.WitherSkull;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
+
+public class DamageSourceSupport
+{
+    public static DamageSource fromNMSDamageSource(NMSDamageSource source)
+    {
+        switch (source.getDamageType())
+        {
+            case NMSDamageSource.ARROW_TYPE:
+                return DamageSource.arrow(
+                        convertEntity(source.getEntity(), EntityArrow.class, org.bukkit.entity.Arrow.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.CACTUS_TYPE:
+                return DamageSource.CACTUS;
+            case NMSDamageSource.CRAMMING_TYPE:
+                return DamageSource.CRAMMING;
+            case NMSDamageSource.DRAGON_BREATH_TYPE:
+                return DamageSource.DRAGON_BREATH;
+            case NMSDamageSource.DROWN_TYPE:
+                return DamageSource.DROWN;
+            case NMSDamageSource.DRYOUT_TYPE:
+                return DamageSource.DRYOUT;
+            case NMSDamageSource.EXPLOSION_TYPE:
+            case NMSDamageSource.EXPLOSION_PLAYER_TYPE:
+                return DamageSource.d(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FALL_TYPE:
+                return DamageSource.FALL;
+            case NMSDamageSource.FALLING_BLOCK_TYPE:
+                return DamageSource.FALLING_BLOCK;
+            case NMSDamageSource.FIREBALL_TYPE:
+                return DamageSource.fireball(
+                        convertEntity(source.getEntity(), EntityFireballFireball.class, org.bukkit.entity.Fireball.class),
+                        convertEntity(source.getDirectEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FIREWORKS_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), EntityFireworks.class, org.bukkit.entity.Firework.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.FLY_INTO_WALL_TYPE:
+                return DamageSource.FLY_INTO_WALL;
+            case NMSDamageSource.GENERIC_TYPE:
+                return DamageSource.GENERIC;
+            case NMSDamageSource.HOT_FLOOR_TYPE:
+                return DamageSource.HOT_FLOOR;
+            case NMSDamageSource.IN_FIRE_TYPE:
+                return DamageSource.FIRE;
+            case NMSDamageSource.IN_WALL_TYPE:
+                return DamageSource.STUCK;
+            case NMSDamageSource.LAVA_TYPE:
+                return DamageSource.LAVA;
+            case NMSDamageSource.LIGHTNING_BOLT_TYPE:
+                return DamageSource.LIGHTNING;
+            case NMSDamageSource.MAGIC_TYPE:
+                return DamageSource.MAGIC;
+            case NMSDamageSource.MOB_TYPE:
+                return DamageSource.mobAttack(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.ON_FIRE_TYPE:
+                return DamageSource.BURN;
+            case NMSDamageSource.OUT_OF_WORLD_TYPE:
+                return DamageSource.OUT_OF_WORLD;
+            case NMSDamageSource.PLAYER_TYPE:
+                return DamageSource.playerAttack(
+                        convertEntity(source.getEntity(), EntityHuman.class, org.bukkit.entity.Player.class)
+                );
+            case NMSDamageSource.STARVE_TYPE:
+                return DamageSource.STARVE;
+            case NMSDamageSource.STING_TYPE:
+                return DamageSource.b(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.SWEET_BERRY_BUSH_TYPE:
+                return DamageSource.SWEET_BERRY_BUSH;
+            case NMSDamageSource.THORNS_TYPE:
+                return DamageSource.a(convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.LivingEntity.class));
+            case NMSDamageSource.INDIRECT_MAGIC_TYPE:
+                return DamageSource.c(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.THROWN_TYPE:
+                return DamageSource.projectile(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.TRIDENT_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Trident.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.WITHER_TYPE:
+                return DamageSource.WITHER;
+            case NMSDamageSource.WITHER_SKULL_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), EntityWitherSkull.class, WitherSkull.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            default:
+                throw new IllegalArgumentException("Unknown damage type: " + source.getDamageType());
+        }
+    }
+
+    private static <T extends Entity> T convertEntity(org.bukkit.entity.Entity entity, Class<T> nmsClazz, Class<? extends org.bukkit.entity.Entity> bukkitClazz)
+    {
+        if (!bukkitClazz.isInstance(entity))
+            throw new IllegalArgumentException("Entity is not an instance of " + bukkitClazz.getName());
+        return nmsClazz.cast(((CraftEntity) entity).getHandle());
+    }
+}

--- a/Scenamatica/NMSBridge/v1_16_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R2/entity/NMSEntityImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R2/entity/NMSEntityImpl.java
@@ -11,7 +11,9 @@ import org.bukkit.craftbukkit.v1_16_R2.entity.CraftEntity;
 import org.jetbrains.annotations.NotNull;
 import org.kunlab.scenamatica.nms.enums.entity.NMSMoveType;
 import org.kunlab.scenamatica.nms.impl.v1_16_R2.TypeSupportImpl;
+import org.kunlab.scenamatica.nms.impl.v1_16_R2.utils.DamageSourceSupport;
 import org.kunlab.scenamatica.nms.impl.v1_16_R2.utils.NMSSupport;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntity;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
@@ -111,6 +113,15 @@ public class NMSEntityImpl implements NMSEntity
             return null;
 
         return new NMSEntityItemImpl(dropped);
+    }
+
+    @Override
+    public boolean damageEntity(NMSDamageSource source, float damage)
+    {
+        return this.nmsEntity.damageEntity(
+                DamageSourceSupport.fromNMSDamageSource(source),
+                damage
+        );
     }
 
     @Override

--- a/Scenamatica/NMSBridge/v1_16_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R2/utils/DamageSourceSupport.java
+++ b/Scenamatica/NMSBridge/v1_16_R2/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R2/utils/DamageSourceSupport.java
@@ -1,0 +1,126 @@
+package org.kunlab.scenamatica.nms.impl.v1_16_R2.utils;
+
+import net.minecraft.server.v1_16_R2.DamageSource;
+import net.minecraft.server.v1_16_R2.Entity;
+import net.minecraft.server.v1_16_R2.EntityArrow;
+import net.minecraft.server.v1_16_R2.EntityFireballFireball;
+import net.minecraft.server.v1_16_R2.EntityFireworks;
+import net.minecraft.server.v1_16_R2.EntityHuman;
+import net.minecraft.server.v1_16_R2.EntityLiving;
+import net.minecraft.server.v1_16_R2.EntityWitherSkull;
+import org.bukkit.craftbukkit.v1_16_R2.entity.CraftEntity;
+import org.bukkit.entity.WitherSkull;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
+
+public class DamageSourceSupport
+{
+    public static DamageSource fromNMSDamageSource(NMSDamageSource source)
+    {
+        switch (source.getDamageType())
+        {
+            case NMSDamageSource.ARROW_TYPE:
+                return DamageSource.arrow(
+                        convertEntity(source.getEntity(), EntityArrow.class, org.bukkit.entity.Arrow.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.CACTUS_TYPE:
+                return DamageSource.CACTUS;
+            case NMSDamageSource.CRAMMING_TYPE:
+                return DamageSource.CRAMMING;
+            case NMSDamageSource.DRAGON_BREATH_TYPE:
+                return DamageSource.DRAGON_BREATH;
+            case NMSDamageSource.DROWN_TYPE:
+                return DamageSource.DROWN;
+            case NMSDamageSource.DRYOUT_TYPE:
+                return DamageSource.DRYOUT;
+            case NMSDamageSource.EXPLOSION_TYPE:
+            case NMSDamageSource.EXPLOSION_PLAYER_TYPE:
+                return DamageSource.d(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FALL_TYPE:
+                return DamageSource.FALL;
+            case NMSDamageSource.FALLING_BLOCK_TYPE:
+                return DamageSource.FALLING_BLOCK;
+            case NMSDamageSource.FIREBALL_TYPE:
+                return DamageSource.fireball(
+                        convertEntity(source.getEntity(), EntityFireballFireball.class, org.bukkit.entity.Fireball.class),
+                        convertEntity(source.getDirectEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FIREWORKS_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), EntityFireworks.class, org.bukkit.entity.Firework.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.FLY_INTO_WALL_TYPE:
+                return DamageSource.FLY_INTO_WALL;
+            case NMSDamageSource.GENERIC_TYPE:
+                return DamageSource.GENERIC;
+            case NMSDamageSource.HOT_FLOOR_TYPE:
+                return DamageSource.HOT_FLOOR;
+            case NMSDamageSource.IN_FIRE_TYPE:
+                return DamageSource.FIRE;
+            case NMSDamageSource.IN_WALL_TYPE:
+                return DamageSource.STUCK;
+            case NMSDamageSource.LAVA_TYPE:
+                return DamageSource.LAVA;
+            case NMSDamageSource.LIGHTNING_BOLT_TYPE:
+                return DamageSource.LIGHTNING;
+            case NMSDamageSource.MAGIC_TYPE:
+                return DamageSource.MAGIC;
+            case NMSDamageSource.MOB_TYPE:
+                return DamageSource.mobAttack(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.ON_FIRE_TYPE:
+                return DamageSource.BURN;
+            case NMSDamageSource.OUT_OF_WORLD_TYPE:
+                return DamageSource.OUT_OF_WORLD;
+            case NMSDamageSource.PLAYER_TYPE:
+                return DamageSource.playerAttack(
+                        convertEntity(source.getEntity(), EntityHuman.class, org.bukkit.entity.Player.class)
+                );
+            case NMSDamageSource.STARVE_TYPE:
+                return DamageSource.STARVE;
+            case NMSDamageSource.STING_TYPE:
+                return DamageSource.b(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.SWEET_BERRY_BUSH_TYPE:
+                return DamageSource.SWEET_BERRY_BUSH;
+            case NMSDamageSource.THORNS_TYPE:
+                return DamageSource.a(convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.LivingEntity.class));
+            case NMSDamageSource.INDIRECT_MAGIC_TYPE:
+                return DamageSource.c(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.THROWN_TYPE:
+                return DamageSource.projectile(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.TRIDENT_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Trident.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.WITHER_TYPE:
+                return DamageSource.WITHER;
+            case NMSDamageSource.WITHER_SKULL_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), EntityWitherSkull.class, WitherSkull.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            default:
+                throw new IllegalArgumentException("Unknown damage type: " + source.getDamageType());
+        }
+    }
+
+    private static <T extends Entity> T convertEntity(org.bukkit.entity.Entity entity, Class<T> nmsClazz, Class<? extends org.bukkit.entity.Entity> bukkitClazz)
+    {
+        if (!bukkitClazz.isInstance(entity))
+            throw new IllegalArgumentException("Entity is not an instance of " + bukkitClazz.getName());
+        return nmsClazz.cast(((CraftEntity) entity).getHandle());
+    }
+}

--- a/Scenamatica/NMSBridge/v1_16_R3/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R3/entity/NMSEntityImpl.java
+++ b/Scenamatica/NMSBridge/v1_16_R3/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R3/entity/NMSEntityImpl.java
@@ -11,7 +11,9 @@ import org.bukkit.craftbukkit.v1_16_R3.entity.CraftEntity;
 import org.jetbrains.annotations.NotNull;
 import org.kunlab.scenamatica.nms.enums.entity.NMSMoveType;
 import org.kunlab.scenamatica.nms.impl.v1_16_R3.TypeSupportImpl;
+import org.kunlab.scenamatica.nms.impl.v1_16_R3.utils.DamageSourceSupport;
 import org.kunlab.scenamatica.nms.impl.v1_16_R3.utils.NMSSupport;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntity;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
@@ -73,6 +75,14 @@ public class NMSEntityImpl implements NMSEntity
         return new NMSEntityItemImpl(dropped);
     }
 
+    @Override
+    public boolean damageEntity(NMSDamageSource source, float damage)
+    {
+        return this.nmsEntity.damageEntity(
+                DamageSourceSupport.fromNMSDamageSource(source),
+                damage
+        );
+    }
     @Override
     public boolean isInvisible()
     {

--- a/Scenamatica/NMSBridge/v1_16_R3/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R3/utils/DamageSourceSupport.java
+++ b/Scenamatica/NMSBridge/v1_16_R3/src/main/java/org/kunlab/scenamatica/nms/impl/v1_16_R3/utils/DamageSourceSupport.java
@@ -1,0 +1,126 @@
+package org.kunlab.scenamatica.nms.impl.v1_16_R3.utils;
+
+import net.minecraft.server.v1_16_R3.DamageSource;
+import net.minecraft.server.v1_16_R3.Entity;
+import net.minecraft.server.v1_16_R3.EntityArrow;
+import net.minecraft.server.v1_16_R3.EntityFireballFireball;
+import net.minecraft.server.v1_16_R3.EntityFireworks;
+import net.minecraft.server.v1_16_R3.EntityHuman;
+import net.minecraft.server.v1_16_R3.EntityLiving;
+import net.minecraft.server.v1_16_R3.EntityWitherSkull;
+import org.bukkit.craftbukkit.v1_16_R3.entity.CraftEntity;
+import org.bukkit.entity.WitherSkull;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
+
+public class DamageSourceSupport
+{
+    public static DamageSource fromNMSDamageSource(NMSDamageSource source)
+    {
+        switch (source.getDamageType())
+        {
+            case NMSDamageSource.ARROW_TYPE:
+                return DamageSource.arrow(
+                        convertEntity(source.getEntity(), EntityArrow.class, org.bukkit.entity.Arrow.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.CACTUS_TYPE:
+                return DamageSource.CACTUS;
+            case NMSDamageSource.CRAMMING_TYPE:
+                return DamageSource.CRAMMING;
+            case NMSDamageSource.DRAGON_BREATH_TYPE:
+                return DamageSource.DRAGON_BREATH;
+            case NMSDamageSource.DROWN_TYPE:
+                return DamageSource.DROWN;
+            case NMSDamageSource.DRYOUT_TYPE:
+                return DamageSource.DRYOUT;
+            case NMSDamageSource.EXPLOSION_TYPE:
+            case NMSDamageSource.EXPLOSION_PLAYER_TYPE:
+                return DamageSource.d(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FALL_TYPE:
+                return DamageSource.FALL;
+            case NMSDamageSource.FALLING_BLOCK_TYPE:
+                return DamageSource.FALLING_BLOCK;
+            case NMSDamageSource.FIREBALL_TYPE:
+                return DamageSource.fireball(
+                        convertEntity(source.getEntity(), EntityFireballFireball.class, org.bukkit.entity.Fireball.class),
+                        convertEntity(source.getDirectEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FIREWORKS_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), EntityFireworks.class, org.bukkit.entity.Firework.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.FLY_INTO_WALL_TYPE:
+                return DamageSource.FLY_INTO_WALL;
+            case NMSDamageSource.GENERIC_TYPE:
+                return DamageSource.GENERIC;
+            case NMSDamageSource.HOT_FLOOR_TYPE:
+                return DamageSource.HOT_FLOOR;
+            case NMSDamageSource.IN_FIRE_TYPE:
+                return DamageSource.FIRE;
+            case NMSDamageSource.IN_WALL_TYPE:
+                return DamageSource.STUCK;
+            case NMSDamageSource.LAVA_TYPE:
+                return DamageSource.LAVA;
+            case NMSDamageSource.LIGHTNING_BOLT_TYPE:
+                return DamageSource.LIGHTNING;
+            case NMSDamageSource.MAGIC_TYPE:
+                return DamageSource.MAGIC;
+            case NMSDamageSource.MOB_TYPE:
+                return DamageSource.mobAttack(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.ON_FIRE_TYPE:
+                return DamageSource.BURN;
+            case NMSDamageSource.OUT_OF_WORLD_TYPE:
+                return DamageSource.OUT_OF_WORLD;
+            case NMSDamageSource.PLAYER_TYPE:
+                return DamageSource.playerAttack(
+                        convertEntity(source.getEntity(), EntityHuman.class, org.bukkit.entity.Player.class)
+                );
+            case NMSDamageSource.STARVE_TYPE:
+                return DamageSource.STARVE;
+            case NMSDamageSource.STING_TYPE:
+                return DamageSource.b(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.SWEET_BERRY_BUSH_TYPE:
+                return DamageSource.SWEET_BERRY_BUSH;
+            case NMSDamageSource.THORNS_TYPE:
+                return DamageSource.a(convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.LivingEntity.class));
+            case NMSDamageSource.INDIRECT_MAGIC_TYPE:
+                return DamageSource.c(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.THROWN_TYPE:
+                return DamageSource.projectile(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.TRIDENT_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Trident.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.WITHER_TYPE:
+                return DamageSource.WITHER;
+            case NMSDamageSource.WITHER_SKULL_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), EntityWitherSkull.class, WitherSkull.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            default:
+                throw new IllegalArgumentException("Unknown damage type: " + source.getDamageType());
+        }
+    }
+
+    private static <T extends Entity> T convertEntity(org.bukkit.entity.Entity entity, Class<T> nmsClazz, Class<? extends org.bukkit.entity.Entity> bukkitClazz)
+    {
+        if (!bukkitClazz.isInstance(entity))
+            throw new IllegalArgumentException("Entity is not an instance of " + bukkitClazz.getName());
+        return nmsClazz.cast(((CraftEntity) entity).getHandle());
+    }
+}

--- a/Scenamatica/NMSBridge/v1_17_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_17_R1/entity/NMSEntityImpl.java
+++ b/Scenamatica/NMSBridge/v1_17_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_17_R1/entity/NMSEntityImpl.java
@@ -11,7 +11,9 @@ import org.bukkit.craftbukkit.v1_17_R1.entity.CraftEntity;
 import org.jetbrains.annotations.NotNull;
 import org.kunlab.scenamatica.nms.enums.entity.NMSMoveType;
 import org.kunlab.scenamatica.nms.impl.v1_17_R1.TypeSupportImpl;
+import org.kunlab.scenamatica.nms.impl.v1_17_R1.utils.DamageSourceSupport;
 import org.kunlab.scenamatica.nms.impl.v1_17_R1.utils.NMSSupport;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntity;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
@@ -73,6 +75,14 @@ public class NMSEntityImpl implements NMSEntity
         return new NMSEntityItemImpl(dropped);
     }
 
+    @Override
+    public boolean damageEntity(NMSDamageSource source, float damage)
+    {
+        return this.nmsEntity.damageEntity(
+                DamageSourceSupport.fromNMSDamageSource(source),
+                damage
+        );
+    }
     @Override
     public boolean isInvisible()
     {

--- a/Scenamatica/NMSBridge/v1_17_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_17_R1/utils/DamageSourceSupport.java
+++ b/Scenamatica/NMSBridge/v1_17_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_17_R1/utils/DamageSourceSupport.java
@@ -1,0 +1,130 @@
+package org.kunlab.scenamatica.nms.impl.v1_17_R1.utils;
+
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityLiving;
+import net.minecraft.world.entity.player.EntityHuman;
+import net.minecraft.world.entity.projectile.EntityArrow;
+import net.minecraft.world.entity.projectile.EntityFireballFireball;
+import net.minecraft.world.entity.projectile.EntityFireworks;
+import net.minecraft.world.entity.projectile.EntityWitherSkull;
+import org.bukkit.craftbukkit.v1_17_R1.entity.CraftEntity;
+import org.bukkit.entity.WitherSkull;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
+
+public class DamageSourceSupport
+{
+    public static DamageSource fromNMSDamageSource(NMSDamageSource source)
+    {
+        switch (source.getDamageType())
+        {
+            case NMSDamageSource.ARROW_TYPE:
+                return DamageSource.arrow(
+                        convertEntity(source.getEntity(), EntityArrow.class, org.bukkit.entity.Arrow.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.CACTUS_TYPE:
+                return DamageSource.j;
+            case NMSDamageSource.CRAMMING_TYPE:
+                return DamageSource.g;
+            case NMSDamageSource.DRAGON_BREATH_TYPE:
+                return DamageSource.s;
+            case NMSDamageSource.DROWN_TYPE:
+                return DamageSource.h;
+            case NMSDamageSource.DRYOUT_TYPE:
+                return DamageSource.t;
+            case NMSDamageSource.EXPLOSION_TYPE:
+            case NMSDamageSource.EXPLOSION_PLAYER_TYPE:
+                return DamageSource.d(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FALL_TYPE:
+                return DamageSource.k;
+            case NMSDamageSource.FALLING_BLOCK_TYPE:
+                return DamageSource.r;
+            case NMSDamageSource.FIREBALL_TYPE:
+                return DamageSource.fireball(
+                        convertEntity(source.getEntity(), EntityFireballFireball.class, org.bukkit.entity.Fireball.class),
+                        convertEntity(source.getDirectEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FIREWORKS_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), EntityFireworks.class, org.bukkit.entity.Firework.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.FLY_INTO_WALL_TYPE:
+                return DamageSource.l;
+            case NMSDamageSource.FREEZE_TYPE:
+                return DamageSource.v;
+            case NMSDamageSource.GENERIC_TYPE:
+                return DamageSource.n;
+            case NMSDamageSource.HOT_FLOOR_TYPE:
+                return DamageSource.e;
+            case NMSDamageSource.IN_FIRE_TYPE:
+                return DamageSource.a;
+            case NMSDamageSource.IN_WALL_TYPE:
+                return DamageSource.f;
+            case NMSDamageSource.LAVA_TYPE:
+                return DamageSource.d;
+            case NMSDamageSource.LIGHTNING_BOLT_TYPE:
+                return DamageSource.b;
+            case NMSDamageSource.MAGIC_TYPE:
+                return DamageSource.o;
+            case NMSDamageSource.MOB_TYPE:
+                return DamageSource.mobAttack(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.ON_FIRE_TYPE:
+                return DamageSource.c;
+            case NMSDamageSource.OUT_OF_WORLD_TYPE:
+                return DamageSource.m;
+            case NMSDamageSource.PLAYER_TYPE:
+                return DamageSource.playerAttack(
+                        convertEntity(source.getEntity(), EntityHuman.class, org.bukkit.entity.Player.class)
+                );
+            case NMSDamageSource.STARVE_TYPE:
+                return DamageSource.i;
+            case NMSDamageSource.STING_TYPE:
+                return DamageSource.b(
+                        convertEntity(source.getEntity(), EntityLiving.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.STALAGMITE_TYPE:
+                return DamageSource.x;
+            case NMSDamageSource.SWEET_BERRY_BUSH_TYPE:
+                return DamageSource.u;
+            case NMSDamageSource.THORNS_TYPE:
+                return DamageSource.a(convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.LivingEntity.class));
+            case NMSDamageSource.INDIRECT_MAGIC_TYPE:
+                return DamageSource.c(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.THROWN_TYPE:
+                return DamageSource.projectile(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.TRIDENT_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Trident.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.WITHER_TYPE:
+                return DamageSource.p;
+            case NMSDamageSource.WITHER_SKULL_TYPE:
+                return DamageSource.a(
+                        convertEntity(source.getEntity(), EntityWitherSkull.class, WitherSkull.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            default:
+                throw new IllegalArgumentException("Unknown damage type: " + source.getDamageType());
+        }
+    }
+
+    private static <T extends Entity> T convertEntity(org.bukkit.entity.Entity entity, Class<T> nmsClazz, Class<? extends org.bukkit.entity.Entity> bukkitClazz)
+    {
+        if (!bukkitClazz.isInstance(entity))
+            throw new IllegalArgumentException("Entity is not an instance of " + bukkitClazz.getName());
+        return nmsClazz.cast(((CraftEntity) entity).getHandle());
+    }
+}

--- a/Scenamatica/NMSBridge/v1_18_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_18_R1/entity/NMSEntityImpl.java
+++ b/Scenamatica/NMSBridge/v1_18_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_18_R1/entity/NMSEntityImpl.java
@@ -11,7 +11,9 @@ import org.bukkit.craftbukkit.v1_18_R1.entity.CraftEntity;
 import org.jetbrains.annotations.NotNull;
 import org.kunlab.scenamatica.nms.enums.entity.NMSMoveType;
 import org.kunlab.scenamatica.nms.impl.v1_18_R1.TypeSupportImpl;
+import org.kunlab.scenamatica.nms.impl.v1_18_R1.utils.DamageSourceSupport;
 import org.kunlab.scenamatica.nms.impl.v1_18_R1.utils.NMSSupport;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntity;
 import org.kunlab.scenamatica.nms.types.entity.NMSEntityItem;
 import org.kunlab.scenamatica.nms.types.item.NMSItemStack;
@@ -73,6 +75,14 @@ public class NMSEntityImpl implements NMSEntity
         return new NMSEntityItemImpl(dropped);
     }
 
+    @Override
+    public boolean damageEntity(NMSDamageSource source, float damage)
+    {
+        return this.nmsEntity.hurt(
+                DamageSourceSupport.fromNMSDamageSource(source),
+                damage
+        );
+    }
     @Override
     public boolean isInvisible()
     {

--- a/Scenamatica/NMSBridge/v1_18_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_18_R1/utils/DamageSourceSupport.java
+++ b/Scenamatica/NMSBridge/v1_18_R1/src/main/java/org/kunlab/scenamatica/nms/impl/v1_18_R1/utils/DamageSourceSupport.java
@@ -1,0 +1,129 @@
+package org.kunlab.scenamatica.nms.impl.v1_18_R1.utils;
+
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.Arrow;
+import net.minecraft.world.entity.projectile.Fireball;
+import net.minecraft.world.entity.projectile.FireworkRocketEntity;
+import net.minecraft.world.entity.projectile.WitherSkull;
+import org.bukkit.craftbukkit.v1_18_R1.entity.CraftEntity;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
+
+public class DamageSourceSupport
+{
+    public static DamageSource fromNMSDamageSource(NMSDamageSource source)
+    {
+        switch (source.getDamageType())
+        {
+            case NMSDamageSource.ARROW_TYPE:
+                return DamageSource.arrow(
+                        convertEntity(source.getEntity(), Arrow.class, org.bukkit.entity.Arrow.class),
+                        convertEntity(source.getDirectEntity(), LivingEntity.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.CACTUS_TYPE:
+                return DamageSource.CACTUS;
+            case NMSDamageSource.CRAMMING_TYPE:
+                return DamageSource.CRAMMING;
+            case NMSDamageSource.DRAGON_BREATH_TYPE:
+                return DamageSource.DRAGON_BREATH;
+            case NMSDamageSource.DROWN_TYPE:
+                return DamageSource.DROWN;
+            case NMSDamageSource.DRYOUT_TYPE:
+                return DamageSource.DRY_OUT;
+            case NMSDamageSource.EXPLOSION_TYPE:
+            case NMSDamageSource.EXPLOSION_PLAYER_TYPE:
+                return DamageSource.explosion(
+                        convertEntity(source.getEntity(), LivingEntity.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FALL_TYPE:
+                return DamageSource.FALL;
+            case NMSDamageSource.FALLING_BLOCK_TYPE:
+                return DamageSource.FALLING_BLOCK;
+            case NMSDamageSource.FIREBALL_TYPE:
+                return DamageSource.fireball(
+                        convertEntity(source.getEntity(), Fireball.class, org.bukkit.entity.Fireball.class),
+                        convertEntity(source.getDirectEntity(), LivingEntity.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.FIREWORKS_TYPE:
+                return DamageSource.fireworks(
+                        convertEntity(source.getEntity(), FireworkRocketEntity.class, org.bukkit.entity.Firework.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.FLY_INTO_WALL_TYPE:
+                return DamageSource.FLY_INTO_WALL;
+            case NMSDamageSource.FREEZE_TYPE:
+                return DamageSource.FREEZE;
+            case NMSDamageSource.GENERIC_TYPE:
+                return DamageSource.GENERIC;
+            case NMSDamageSource.HOT_FLOOR_TYPE:
+                return DamageSource.HOT_FLOOR;
+            case NMSDamageSource.IN_FIRE_TYPE:
+                return DamageSource.IN_FIRE;
+            case NMSDamageSource.IN_WALL_TYPE:
+                return DamageSource.IN_WALL;
+            case NMSDamageSource.LAVA_TYPE:
+                return DamageSource.LAVA;
+            case NMSDamageSource.LIGHTNING_BOLT_TYPE:
+                return DamageSource.LIGHTNING_BOLT;
+            case NMSDamageSource.MAGIC_TYPE:
+                return DamageSource.MAGIC;
+            case NMSDamageSource.MOB_TYPE:
+                return DamageSource.mobAttack(
+                        convertEntity(source.getEntity(), LivingEntity.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.ON_FIRE_TYPE:
+                return DamageSource.ON_FIRE;
+            case NMSDamageSource.OUT_OF_WORLD_TYPE:
+                return DamageSource.OUT_OF_WORLD;
+            case NMSDamageSource.PLAYER_TYPE:
+                return DamageSource.playerAttack(
+                        convertEntity(source.getEntity(), Player.class, org.bukkit.entity.Player.class)
+                );
+            case NMSDamageSource.STARVE_TYPE:
+                return DamageSource.STARVE;
+            case NMSDamageSource.STING_TYPE:
+                return DamageSource.sting(
+                        convertEntity(source.getEntity(), LivingEntity.class, org.bukkit.entity.LivingEntity.class)
+                );
+            case NMSDamageSource.STALAGMITE_TYPE:
+                return DamageSource.STALAGMITE;
+            case NMSDamageSource.SWEET_BERRY_BUSH_TYPE:
+                return DamageSource.SWEET_BERRY_BUSH;
+            case NMSDamageSource.THORNS_TYPE:
+                return DamageSource.thorns(convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.LivingEntity.class));
+            case NMSDamageSource.INDIRECT_MAGIC_TYPE:
+                return DamageSource.indirectMagic(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.THROWN_TYPE:
+                return DamageSource.thrown(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Entity.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.TRIDENT_TYPE:
+                return DamageSource.trident(
+                        convertEntity(source.getEntity(), Entity.class, org.bukkit.entity.Trident.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            case NMSDamageSource.WITHER_TYPE:
+                return DamageSource.WITHER;
+            case NMSDamageSource.WITHER_SKULL_TYPE:
+                return DamageSource.witherSkull(
+                        convertEntity(source.getEntity(), WitherSkull.class, org.bukkit.entity.WitherSkull.class),
+                        convertEntity(source.getDirectEntity(), Entity.class, org.bukkit.entity.Entity.class)
+                );
+            default:
+                throw new IllegalArgumentException("Unknown damage type: " + source.getDamageType());
+        }
+    }
+
+    private static <T extends Entity> T convertEntity(org.bukkit.entity.Entity entity, Class<T> nmsClazz, Class<? extends org.bukkit.entity.Entity> bukkitClazz)
+    {
+        if (!bukkitClazz.isInstance(entity))
+            throw new IllegalArgumentException("Entity is not an instance of " + bukkitClazz.getName());
+        return nmsClazz.cast(((CraftEntity) entity).getHandle());
+    }
+}

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/AbstractEntityAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/AbstractEntityAction.java
@@ -78,6 +78,8 @@ public abstract class AbstractEntityAction<E extends Entity, V extends EntityStr
 
     public E selectTarget(@NotNull ActionContext ctxt)
     {
+        if (!ctxt.hasInput(this.IN_TARGET_ENTITY))
+            throw new IllegalActionInputException(this.IN_TARGET_ENTITY, "You must specify the target entity for this action.");
         return ctxt.input(this.IN_TARGET_ENTITY).selectTarget(ctxt.getContext())
                 .orElseThrow(() -> new IllegalActionInputException(this.IN_TARGET_ENTITY, "Cannot select target for this action, please specify target with valid specifier."));
     }

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/EntitySpawnAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/EntitySpawnAction.java
@@ -27,6 +27,7 @@ import org.kunlab.scenamatica.interfaces.structures.specifiers.EntitySpecifier;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 @Action("entity_spawn")
 @ActionDoc(
@@ -76,7 +77,7 @@ public class EntitySpawnAction<E extends Entity> extends AbstractAction
         this((Class<E>) Entity.class, EntityStructure.class);
     }
 
-    public <T extends Entity> T spawnEntity(ActionContext ctxt, EntityStructure structure, @Nullable LocationStructure locDef)
+    public static <T extends Entity> T spawnEntity(ActionContext ctxt, EntityStructure structure, @Nullable LocationStructure locDef, Consumer<? super T> consumer)
     {
         Location spawnLoc = locDef == null ? null: locDef.create();
         if (spawnLoc == null)
@@ -94,7 +95,7 @@ public class EntitySpawnAction<E extends Entity> extends AbstractAction
                 entityClass,
                 entity -> {
                     structure.applyTo(entity);
-                    this.makeOutputs(ctxt, entity);
+                    consumer.accept(entity);
                 }
         );
     }
@@ -106,7 +107,7 @@ public class EntitySpawnAction<E extends Entity> extends AbstractAction
         assert structure != null;
         LocationStructure spawnLoc = structure.getLocation();
 
-        this.spawnEntity(ctxt, structure, spawnLoc);
+        spawnEntity(ctxt, structure, spawnLoc, e -> this.makeOutputs(ctxt, e));
     }
 
     protected void makeOutputs(@NotNull ActionContext ctxt, @NotNull Entity entity)

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/AbstractVehicleAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/AbstractVehicleAction.java
@@ -1,0 +1,26 @@
+package org.kunlab.scenamatica.action.actions.base.entity.vehicle;
+
+import org.bukkit.entity.Vehicle;
+import org.bukkit.event.Event;
+import org.bukkit.event.vehicle.VehicleEvent;
+import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.action.actions.base.entity.AbstractEntityAction;
+import org.kunlab.scenamatica.interfaces.action.ActionContext;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities.VehicleStructure;
+
+public abstract class AbstractVehicleAction extends AbstractEntityAction<Vehicle, VehicleStructure>
+{
+    public AbstractVehicleAction()
+    {
+        super(Vehicle.class, VehicleStructure.class);
+    }
+
+    protected boolean checkMatchedVehicleEvent(@NotNull ActionContext ctxt, @NotNull Event event)
+    {
+        if (!(event instanceof VehicleEvent))
+            return false;
+
+        VehicleEvent e = (VehicleEvent) event;
+        return ctxt.ifHasInput(this.IN_TARGET_ENTITY, specifier -> specifier.checkMatchedEntity(e.getVehicle()));
+    }
+}

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/AbstractVehicleAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/AbstractVehicleAction.java
@@ -1,5 +1,7 @@
 package org.kunlab.scenamatica.action.actions.base.entity.vehicle;
 
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.event.Event;
 import org.bukkit.event.vehicle.VehicleEvent;
@@ -13,6 +15,20 @@ public abstract class AbstractVehicleAction extends AbstractEntityAction<Vehicle
     public AbstractVehicleAction()
     {
         super(Vehicle.class, VehicleStructure.class);
+    }
+
+    public static boolean isVehicleEntity(@NotNull Class<? extends Entity> entity)
+    {
+        return Vehicle.class.isAssignableFrom(entity);
+    }
+
+    public static boolean isVehicleEntity(@NotNull EntityType type)
+    {
+        if (type == EntityType.UNKNOWN)
+            return false;
+        assert type.getEntityClass() != null;  // EntityType.UNKNOWN のときのみ null なので。
+
+        return isVehicleEntity(type.getEntityClass());
     }
 
     protected boolean checkMatchedVehicleEvent(@NotNull ActionContext ctxt, @NotNull Event event)

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleCreateAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleCreateAction.java
@@ -1,0 +1,67 @@
+package org.kunlab.scenamatica.action.actions.base.entity.vehicle;
+
+import org.bukkit.entity.Vehicle;
+import org.bukkit.event.Event;
+import org.bukkit.event.vehicle.VehicleCreateEvent;
+import org.jetbrains.annotations.NotNull;
+import org.kunlab.scenamatica.action.actions.base.entity.EntitySpawnAction;
+import org.kunlab.scenamatica.annotations.action.Action;
+import org.kunlab.scenamatica.bookkeeper.annotations.ActionDoc;
+import org.kunlab.scenamatica.exceptions.scenario.IllegalActionInputException;
+import org.kunlab.scenamatica.interfaces.action.ActionContext;
+import org.kunlab.scenamatica.interfaces.action.types.Executable;
+import org.kunlab.scenamatica.interfaces.action.types.Expectable;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.EntityStructure;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.misc.LocationStructure;
+
+import java.util.Collections;
+import java.util.List;
+
+@Action("vehicle_create")
+@ActionDoc(
+        name = "乗り物の生成",
+        description = "乗り物を生成します。",
+        events = {
+                VehicleCreateEvent.class
+        },
+
+        executable = "乗り物を生成します。",
+        expectable = "乗り物が生成されることを期待します。",
+        requireable = ActionDoc.UNALLOWED
+)
+public class VehicleCreateAction extends AbstractVehicleAction
+        implements Executable, Expectable
+{
+    @Override
+    public void execute(@NotNull ActionContext ctxt)
+    {
+        EntityStructure structure = ctxt.input(this.IN_TARGET_ENTITY).getTargetStructure();
+        assert structure != null;
+        LocationStructure spawnLoc = structure.getLocation();
+
+        if (!isVehicleEntity(structure.getType()))
+            throw new IllegalActionInputException(this.IN_TARGET_ENTITY, "Not a vehicle entity provided.");
+
+        EntitySpawnAction.<Vehicle>spawnEntity(ctxt, structure, spawnLoc, e -> this.makeOutputs(ctxt, e));
+    }
+
+    @Override
+    public boolean checkFired(@NotNull ActionContext ctxt, @NotNull Event event)
+    {
+        if (!super.checkMatchedVehicleEvent(ctxt, event))
+            return false;
+
+        assert event instanceof VehicleCreateEvent;
+        VehicleCreateEvent e = (VehicleCreateEvent) event;
+
+        this.makeOutputs(ctxt, e.getVehicle());
+
+        return true;
+    }
+
+    @Override
+    public List<Class<? extends Event>> getAttachingEvents()
+    {
+        return Collections.singletonList(VehicleCreateEvent.class);
+    }
+}

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleDamageAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleDamageAction.java
@@ -1,0 +1,137 @@
+package org.kunlab.scenamatica.action.actions.base.entity.vehicle;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Vehicle;
+import org.bukkit.event.Event;
+import org.bukkit.event.vehicle.VehicleDamageEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.kunlab.scenamatica.annotations.action.Action;
+import org.kunlab.scenamatica.bookkeeper.annotations.ActionDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.InputDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.OutputDoc;
+import org.kunlab.scenamatica.bookkeeper.enums.ActionMethod;
+import org.kunlab.scenamatica.enums.ScenarioType;
+import org.kunlab.scenamatica.exceptions.scenario.IllegalActionInputException;
+import org.kunlab.scenamatica.interfaces.action.ActionContext;
+import org.kunlab.scenamatica.interfaces.action.input.InputBoard;
+import org.kunlab.scenamatica.interfaces.action.input.InputToken;
+import org.kunlab.scenamatica.interfaces.action.types.Executable;
+import org.kunlab.scenamatica.interfaces.action.types.Expectable;
+import org.kunlab.scenamatica.interfaces.structures.specifiers.EntitySpecifier;
+import org.kunlab.scenamatica.nms.NMSProvider;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
+import org.kunlab.scenamatica.nms.types.entity.NMSEntity;
+
+import java.util.Collections;
+import java.util.List;
+
+@Action("vehicle_damage")
+@ActionDoc(
+        name = "乗り物の負傷",
+        description = "乗り物にダメージを与えます。",
+        events = {
+                VehicleDamageEvent.class
+        },
+        executable = "乗り物にダメージを与えます。",
+        expectable = "乗り物がダメージを受けることを期待します。",
+        requireable = ActionDoc.UNALLOWED,
+
+        outputs = {
+                @OutputDoc(
+                        name = VehicleDamageAction.OUT_ATTACKER,
+                        description = "ダメージを与えたエンティティです。",
+                        type = Entity.class
+                ),
+                @OutputDoc(
+                        name = VehicleDamageAction.OUT_DAMAGE,
+                        description = "与えたダメージの量です。",
+                        type = double.class
+                )
+        }
+)
+public class VehicleDamageAction extends AbstractVehicleAction
+        implements Executable, Expectable
+{
+    @InputDoc(
+            name = "attacker",
+            description = "ダメージを与えたエンティティを指定します。",
+            type = EntitySpecifier.class
+    )
+    public static final InputToken<EntitySpecifier<Entity>> IN_ATTACKER = ofSpecifier("attacker");
+
+    @InputDoc(
+            name = "amount",
+            description = "ダメージの量を指定します。",
+            type = double.class,
+            requiredOn = ActionMethod.EXECUTE
+    )
+    public static final InputToken<Double> IN_AMOUNT = ofInput(
+            "amount",
+            Double.class
+    );
+
+    public static final String OUT_ATTACKER = "attacker";
+    public static final String OUT_DAMAGE = "damage";
+
+    @Override
+    public void execute(@NotNull ActionContext ctxt)
+    {
+        Vehicle vehicle = this.selectTarget(ctxt);
+        Entity attacker = null;
+        if (ctxt.hasInput(IN_ATTACKER))
+            attacker = ctxt.input(IN_ATTACKER).selectTarget(ctxt.getContext())
+                    .orElseThrow(() -> new IllegalActionInputException("The attacker entity is not found."));
+        double damage = ctxt.input(IN_AMOUNT);
+
+        this.makeOutputs(ctxt, vehicle, attacker, damage);
+
+        NMSEntity nmsEntity = NMSProvider.getProvider().wrap(vehicle);
+        NMSDamageSource damageSource;
+        if (attacker == null)
+            damageSource = NMSDamageSource.GENERIC;
+        else
+            damageSource = NMSDamageSource.anyEntityAttack(attacker);
+
+        nmsEntity.damageEntity(damageSource, (float) damage);
+    }
+
+    @Override
+    public boolean checkFired(@NotNull ActionContext ctxt, @NotNull Event event)
+    {
+        if (!super.checkMatchedVehicleEvent(ctxt, event))
+            return false;
+        assert event instanceof VehicleDamageEvent;
+        VehicleDamageEvent e = (VehicleDamageEvent) event;
+
+        boolean result = ctxt.ifHasInput(IN_ATTACKER, attacker -> attacker.checkMatchedEntity(e.getAttacker()));
+        if (result)
+            this.makeOutputs(ctxt, e.getVehicle(), e.getAttacker(), e.getDamage());
+
+        return result;
+    }
+
+    protected void makeOutputs(@NotNull ActionContext ctxt, @Nullable Vehicle vehicle, @Nullable Entity attacker, @Nullable Double damage)
+    {
+        if (attacker != null)
+            ctxt.output(OUT_ATTACKER, attacker);
+        if (damage != null)
+            ctxt.output(OUT_DAMAGE, damage);
+        super.makeOutputs(ctxt, vehicle);
+    }
+
+    @Override
+    public List<Class<? extends Event>> getAttachingEvents()
+    {
+        return Collections.singletonList(
+                VehicleDamageEvent.class
+        );
+    }
+
+    @Override
+    public InputBoard getInputBoard(ScenarioType type)
+    {
+        return super.getInputBoard(type)
+                .registerAll(IN_AMOUNT, IN_ATTACKER);
+    }
+}

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleDestroyAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleDestroyAction.java
@@ -48,11 +48,6 @@ import java.util.Optional;
 
         outputs = {
                 @OutputDoc(
-                        name = VehicleDestroyAction.OUT_VEHICLE,
-                        description = "破壊された乗り物です。",
-                        type = Vehicle.class
-                ),
-                @OutputDoc(
                         name = VehicleDestroyAction.OUT_ATTACKER,
                         description = "乗り物を破壊したエンティティです。",
                         type = Entity.class
@@ -69,7 +64,6 @@ public class VehicleDestroyAction extends AbstractVehicleAction
     )
     public static final InputToken<EntitySpecifier<Entity>> IN_ATTACKER = ofSpecifier("attacker");
 
-    public static final String OUT_VEHICLE = "vehicle";
     public static final String OUT_ATTACKER = "attacker";
 
     @Override
@@ -123,8 +117,6 @@ public class VehicleDestroyAction extends AbstractVehicleAction
 
     protected void makeOutputs(@NotNull ActionContext ctxt, @Nullable Vehicle vehicle, @Nullable Entity attacker)
     {
-        if (vehicle != null)
-            ctxt.output(OUT_VEHICLE, vehicle);
         if (attacker != null)
             ctxt.output(OUT_ATTACKER, attacker);
         super.makeOutputs(ctxt, vehicle);

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleDestroyAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleDestroyAction.java
@@ -1,0 +1,150 @@
+package org.kunlab.scenamatica.action.actions.base.entity.vehicle;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Vehicle;
+import org.bukkit.event.Event;
+import org.bukkit.event.vehicle.VehicleDestroyEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.kunlab.scenamatica.annotations.action.Action;
+import org.kunlab.scenamatica.bookkeeper.annotations.ActionDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.Admonition;
+import org.kunlab.scenamatica.bookkeeper.annotations.InputDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.OutputDoc;
+import org.kunlab.scenamatica.bookkeeper.enums.AdmonitionType;
+import org.kunlab.scenamatica.enums.ScenarioType;
+import org.kunlab.scenamatica.exceptions.scenario.IllegalActionInputException;
+import org.kunlab.scenamatica.interfaces.action.ActionContext;
+import org.kunlab.scenamatica.interfaces.action.input.InputBoard;
+import org.kunlab.scenamatica.interfaces.action.input.InputToken;
+import org.kunlab.scenamatica.interfaces.action.types.Executable;
+import org.kunlab.scenamatica.interfaces.action.types.Expectable;
+import org.kunlab.scenamatica.interfaces.action.types.Requireable;
+import org.kunlab.scenamatica.interfaces.structures.specifiers.EntitySpecifier;
+import org.kunlab.scenamatica.nms.NMSProvider;
+import org.kunlab.scenamatica.nms.types.entity.NMSDamageSource;
+import org.kunlab.scenamatica.nms.types.entity.NMSEntity;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Action("vehicle_destroy")
+@ActionDoc(
+        name = "乗り物の破壊",
+        description = "乗り物を破壊します。",
+        events = {
+                VehicleDestroyEvent.class
+        },
+        executable = "乗り物を破壊します。",
+        expectable = "乗り物が破壊されることを期待します。",
+        requireable = "乗り物が破壊されたかどうかを確認します。",
+        admonitions = {
+                @Admonition(
+                        type = AdmonitionType.NOTE,
+                        content = "このアクションは, 乗り物を破壊するために, 乗り物に 40.1f のダメージを与えます。"
+                )
+        },
+
+        outputs = {
+                @OutputDoc(
+                        name = VehicleDestroyAction.OUT_VEHICLE,
+                        description = "破壊された乗り物です。",
+                        type = Vehicle.class
+                ),
+                @OutputDoc(
+                        name = VehicleDestroyAction.OUT_ATTACKER,
+                        description = "乗り物を破壊したエンティティです。",
+                        type = Entity.class
+                )
+        }
+)
+public class VehicleDestroyAction extends AbstractVehicleAction
+        implements Executable, Expectable, Requireable
+{
+    @InputDoc(
+            name = "attacker",
+            description = "乗り物を破壊したエンティティです。",
+            type = EntitySpecifier.class
+    )
+    public static final InputToken<EntitySpecifier<Entity>> IN_ATTACKER = ofSpecifier("attacker");
+
+    public static final String OUT_VEHICLE = "vehicle";
+    public static final String OUT_ATTACKER = "attacker";
+
+    @Override
+    public void execute(@NotNull ActionContext ctxt)
+    {
+        Vehicle vehicle = this.selectTarget(ctxt);
+        Entity attacker = null;
+        if (ctxt.hasInput(IN_ATTACKER))
+            attacker = ctxt.input(IN_ATTACKER).selectTarget(ctxt.getContext())
+                    .orElseThrow(() -> new IllegalActionInputException("The attacker entity is not found."));
+
+        this.makeOutputs(ctxt, vehicle, attacker);
+
+        NMSEntity nmsEntity = NMSProvider.getProvider().wrap(vehicle);
+        NMSDamageSource damageSource = NMSDamageSource.anyEntityAttack(attacker);
+        // 40.0f より大きいダメージを与えることで, 乗り物を破壊する（この値は ソースにハードコーディングされている）
+        nmsEntity.damageEntity(damageSource, 40.1f);
+    }
+
+    @Override
+    public boolean checkFired(@NotNull ActionContext ctxt, @NotNull Event event)
+    {
+        if (!super.checkMatchedVehicleEvent(ctxt, event))
+            return false;
+        assert event instanceof VehicleDestroyEvent;
+        VehicleDestroyEvent e = (VehicleDestroyEvent) event;
+
+        boolean result = ctxt.ifHasInput(IN_ATTACKER, attacker -> attacker.checkMatchedEntity(e.getAttacker()));
+        if (result)
+            this.makeOutputs(ctxt, e.getVehicle(), e.getAttacker());
+
+        return result;
+    }
+
+    @Override
+    public boolean checkConditionFulfilled(@NotNull ActionContext ctxt)
+    {
+        // エンティティは存在しないことを許容するので, super#searchEntity は使わない
+        if (!ctxt.hasInput(this.IN_TARGET_ENTITY))
+            throw new IllegalActionInputException(this.IN_TARGET_ENTITY, "You must specify the target entity.");
+
+        Optional<Vehicle> vehicle = ctxt.input(this.IN_TARGET_ENTITY)
+                .selectTarget(ctxt.getContext());
+        boolean result = !vehicle.isPresent()  // 乗り物が存在しない場合も破壊されたとみなす
+                || vehicle.get().isDead();
+        if (result)
+            this.makeOutputs(ctxt, vehicle.orElse(null), null);
+
+        return result;
+    }
+
+    protected void makeOutputs(@NotNull ActionContext ctxt, @Nullable Vehicle vehicle, @Nullable Entity attacker)
+    {
+        if (vehicle != null)
+            ctxt.output(OUT_VEHICLE, vehicle);
+        if (attacker != null)
+            ctxt.output(OUT_ATTACKER, attacker);
+        super.makeOutputs(ctxt, vehicle);
+    }
+
+    @Override
+    public List<Class<? extends Event>> getAttachingEvents()
+    {
+        return Collections.singletonList(
+                VehicleDestroyEvent.class
+        );
+    }
+
+    @Override
+    public InputBoard getInputBoard(ScenarioType type)
+    {
+        InputBoard board = super.getInputBoard(type);
+        if (type != ScenarioType.CONDITION_REQUIRE)
+            board.register(IN_ATTACKER);
+
+        return board;
+    }
+}

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleEnterAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleEnterAction.java
@@ -94,9 +94,8 @@ public class VehicleEnterAction extends AbstractVehicleAction
             if (!ctxt.hasInput(IN_PASSENGER))
                 throw new IllegalActionInputException(IN_PASSENGER, "You must specify the entity to board the vehicle if you do not specify the vehicle.");
 
-            Entity entity = ctxt.input(IN_PASSENGER).selectTarget(ctxt.getContext()).orElse(null);
-            if (entity == null)
-                throw new IllegalActionInputException(IN_PASSENGER, "Unable to find the entity to board the vehicle.");
+            Entity entity = ctxt.input(IN_PASSENGER).selectTarget(ctxt.getContext())
+                    .orElseThrow(() -> new IllegalActionInputException(IN_PASSENGER, "Unable to find the entity to board the vehicle."));
 
             return entity.isInsideVehicle();
         }

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleEnterAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleEnterAction.java
@@ -1,0 +1,126 @@
+package org.kunlab.scenamatica.action.actions.base.entity.vehicle;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Vehicle;
+import org.bukkit.event.Event;
+import org.bukkit.event.vehicle.VehicleEnterEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.kunlab.scenamatica.bookkeeper.annotations.ActionDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.InputDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.OutputDoc;
+import org.kunlab.scenamatica.enums.ScenarioType;
+import org.kunlab.scenamatica.exceptions.scenario.IllegalActionInputException;
+import org.kunlab.scenamatica.interfaces.action.ActionContext;
+import org.kunlab.scenamatica.interfaces.action.input.InputBoard;
+import org.kunlab.scenamatica.interfaces.action.input.InputToken;
+import org.kunlab.scenamatica.interfaces.action.types.Executable;
+import org.kunlab.scenamatica.interfaces.action.types.Expectable;
+import org.kunlab.scenamatica.interfaces.action.types.Requireable;
+import org.kunlab.scenamatica.interfaces.structures.specifiers.EntitySpecifier;
+
+import java.util.Collections;
+import java.util.List;
+
+@ActionDoc(
+        name = "乗り物への搭乗",
+        description = "エンティティを乗り物に搭乗させます。",
+        events = {
+                VehicleEnterEvent.class
+        },
+        executable = "エンティティを乗り物に搭乗させます。",
+        expectable = "エンティティが乗り物に搭乗することを期待します。",
+        requireable = "エンティティが乗り物に搭乗しているかどうかを確認します。",
+
+        outputs = {
+                @OutputDoc(
+                        name = VehicleEnterAction.OUT_ENTITY,
+                        description = "搭乗したエンティティです。",
+                        type = Entity.class
+                )
+        }
+)
+public class VehicleEnterAction extends AbstractVehicleAction
+        implements Executable, Expectable, Requireable
+{
+    public static final String OUT_ENTITY = "passenger";
+
+    @InputDoc(
+            name = "passenger",
+            description = "乗り物に搭乗するエンティティです。",
+            type = EntitySpecifier.class
+    )
+    public static final InputToken<EntitySpecifier<Entity>> IN_ENTITY = ofSpecifier("entity");
+
+    @Override
+    public void execute(@NotNull ActionContext ctxt)
+    {
+        Vehicle vehicle = this.selectTarget(ctxt);
+        // エンティティを取得し, もし存在しない場合は例外をスローする。
+        Entity entity = ctxt.input(IN_ENTITY).selectTarget(ctxt.getContext())
+                .orElseThrow(() -> new IllegalActionInputException(IN_ENTITY, "Unable to find the entity to board the vehicle."));
+
+        this.makeOutputs(ctxt, vehicle, entity);
+        vehicle.addPassenger(entity);
+    }
+
+    @Override
+    public boolean checkFired(@NotNull ActionContext ctxt, @NotNull Event event)
+    {
+        if (!super.checkMatchedVehicleEvent(ctxt, event))
+            return false;
+        assert event instanceof VehicleEnterEvent;
+        VehicleEnterEvent e = (VehicleEnterEvent) event;
+
+        Entity entity = e.getEntered();  // 搭乗したエンティティ
+
+        // ↓ 乗り物自体の比較は, #checkMatchedVehicleEvent で行っているので, ここではエンティティの比較のみ行う。
+        boolean result = ctxt.ifHasInput(IN_ENTITY, inputEntity -> inputEntity.checkMatchedEntity(entity));
+        if (result)
+            this.makeOutputs(ctxt, e.getVehicle(), entity);
+
+        return result;
+    }
+
+    @Override
+    public boolean checkConditionFulfilled(@NotNull ActionContext ctxt)
+    {
+        Vehicle vehicle = this.selectTarget(ctxt);
+        Entity entity = ctxt.input(IN_ENTITY).selectTarget(ctxt.getContext()).orElse(null);
+        if (ctxt.hasInput(IN_ENTITY) && entity == null)
+            throw new IllegalActionInputException(IN_ENTITY, "Unable to find the entity to board the vehicle.");
+
+        boolean result = vehicle.getPassengers().contains(entity);
+        if (result)
+            this.makeOutputs(ctxt, vehicle, entity);
+
+        return result;
+    }
+
+    @Override
+    public List<Class<? extends Event>> getAttachingEvents()
+    {
+        return Collections.singletonList(
+                VehicleEnterEvent.class
+        );
+    }
+
+    private void makeOutputs(@NotNull ActionContext ctxt, @NotNull Vehicle vehicle, @Nullable Entity entity)
+    {
+        if (entity != null)
+            ctxt.output(OUT_ENTITY, entity);
+        super.makeOutputs(ctxt, vehicle);
+    }
+
+    @Override
+    public InputBoard getInputBoard(ScenarioType type)
+    {
+        InputBoard board = super.getInputBoard(type)
+                .register(IN_ENTITY);
+        // アクション実行シナリオの場合は, "entity" を必須とする。
+        if (type == ScenarioType.ACTION_EXECUTE)
+            board.requirePresent(IN_ENTITY);
+
+        return board;
+    }
+}

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleEnterAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleEnterAction.java
@@ -87,12 +87,17 @@ public class VehicleEnterAction extends AbstractVehicleAction
     @Override
     public boolean checkConditionFulfilled(@NotNull ActionContext ctxt)
     {
-        Vehicle vehicle = this.selectTarget(ctxt);
-        Entity entity = ctxt.input(IN_ENTITY).selectTarget(ctxt.getContext()).orElse(null);
-        if (ctxt.hasInput(IN_ENTITY) && entity == null)
-            throw new IllegalActionInputException(IN_ENTITY, "Unable to find the entity to board the vehicle.");
+        Entity entity = ctxt.input(IN_ENTITY).selectTarget(ctxt.getContext())
+                .orElseThrow(() -> new IllegalActionInputException(IN_ENTITY, "Unable to find the entity to board the vehicle."));
 
-        boolean result = vehicle.getPassengers().contains(entity);
+        Vehicle vehicle = null;
+        boolean result = entity.isInsideVehicle();
+        if (ctxt.hasInput(IN_ENTITY))  // エンティティ（このアクションの場合は乗り物）が指定されている場合は：
+        {
+            vehicle = this.selectTarget(ctxt);
+            result = vehicle.getPassengers().contains(entity);
+        }
+
         if (result)
             this.makeOutputs(ctxt, vehicle, entity);
 
@@ -107,7 +112,7 @@ public class VehicleEnterAction extends AbstractVehicleAction
         );
     }
 
-    private void makeOutputs(@NotNull ActionContext ctxt, @NotNull Vehicle vehicle, @Nullable Entity entity)
+    private void makeOutputs(@NotNull ActionContext ctxt, @Nullable Vehicle vehicle, @Nullable Entity entity)
     {
         if (entity != null)
             ctxt.output(OUT_ENTITY, entity);

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleEnterAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleEnterAction.java
@@ -52,7 +52,7 @@ public class VehicleEnterAction extends AbstractVehicleAction
             description = "乗り物に搭乗するエンティティです。",
             type = EntitySpecifier.class
     )
-    public static final InputToken<EntitySpecifier<Entity>> IN_ENTITY = ofSpecifier("entity");
+    public static final InputToken<EntitySpecifier<Entity>> IN_ENTITY = ofSpecifier("passenger");
 
     @Override
     public void execute(@NotNull ActionContext ctxt)

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleEnterAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleEnterAction.java
@@ -6,6 +6,7 @@ import org.bukkit.event.Event;
 import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.kunlab.scenamatica.annotations.action.Action;
 import org.kunlab.scenamatica.bookkeeper.annotations.ActionDoc;
 import org.kunlab.scenamatica.bookkeeper.annotations.InputDoc;
 import org.kunlab.scenamatica.bookkeeper.annotations.OutputDoc;
@@ -22,6 +23,7 @@ import org.kunlab.scenamatica.interfaces.structures.specifiers.EntitySpecifier;
 import java.util.Collections;
 import java.util.List;
 
+@Action("vehicle_enter")
 @ActionDoc(
         name = "乗り物への搭乗",
         description = "エンティティを乗り物に搭乗させます。",

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleExitAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleExitAction.java
@@ -115,7 +115,8 @@ public class VehicleExitAction extends AbstractVehicleAction
     @Override
     public InputBoard getInputBoard(ScenarioType type)
     {
-        InputBoard board = ofInputs(type, IN_ENTITY);
+        InputBoard board = super.getInputBoard(type)
+                .register(IN_ENTITY);
         if (type == ScenarioType.ACTION_EXECUTE)
             board.requirePresent(IN_ENTITY);
 

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleExitAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleExitAction.java
@@ -7,6 +7,7 @@ import org.bukkit.event.Event;
 import org.bukkit.event.vehicle.VehicleExitEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.kunlab.scenamatica.annotations.action.Action;
 import org.kunlab.scenamatica.bookkeeper.annotations.ActionDoc;
 import org.kunlab.scenamatica.bookkeeper.annotations.OutputDoc;
 import org.kunlab.scenamatica.exceptions.scenario.IllegalActionInputException;
@@ -20,6 +21,7 @@ import org.kunlab.scenamatica.interfaces.structures.specifiers.EntitySpecifier;
 import java.util.Collections;
 import java.util.List;
 
+@Action("vehicle_exit")
 @ActionDoc(
         name = "乗り物からの後者",
         description = "エンティティを乗り物から降ろします。",

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleExitAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleExitAction.java
@@ -48,7 +48,7 @@ public class VehicleExitAction extends AbstractVehicleAction
 {
     public static final String OUT_ENTITY = "passenger";
 
-    public static final InputToken<EntitySpecifier<Entity>> IN_ENTITY = ofSpecifier("entity");
+    public static final InputToken<EntitySpecifier<Entity>> IN_ENTITY = ofSpecifier("passenger");
 
     @Override
     public void execute(@NotNull ActionContext ctxt)

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleExitAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleExitAction.java
@@ -10,8 +10,10 @@ import org.jetbrains.annotations.Nullable;
 import org.kunlab.scenamatica.annotations.action.Action;
 import org.kunlab.scenamatica.bookkeeper.annotations.ActionDoc;
 import org.kunlab.scenamatica.bookkeeper.annotations.OutputDoc;
+import org.kunlab.scenamatica.enums.ScenarioType;
 import org.kunlab.scenamatica.exceptions.scenario.IllegalActionInputException;
 import org.kunlab.scenamatica.interfaces.action.ActionContext;
+import org.kunlab.scenamatica.interfaces.action.input.InputBoard;
 import org.kunlab.scenamatica.interfaces.action.input.InputToken;
 import org.kunlab.scenamatica.interfaces.action.types.Executable;
 import org.kunlab.scenamatica.interfaces.action.types.Expectable;
@@ -108,5 +110,15 @@ public class VehicleExitAction extends AbstractVehicleAction
         return Collections.singletonList(
                 VehicleExitEvent.class
         );
+    }
+
+    @Override
+    public InputBoard getInputBoard(ScenarioType type)
+    {
+        InputBoard board = ofInputs(type, IN_ENTITY);
+        if (type == ScenarioType.ACTION_EXECUTE)
+            board.requirePresent(IN_ENTITY);
+
+        return board;
     }
 }

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleExitAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleExitAction.java
@@ -48,19 +48,19 @@ public class VehicleExitAction extends AbstractVehicleAction
 {
     public static final String OUT_ENTITY = "passenger";
 
-    public static final InputToken<EntitySpecifier<Entity>> IN_ENTITY = ofSpecifier("passenger");
+    public static final InputToken<EntitySpecifier<Entity>> IN_PASSENGER = ofSpecifier("passenger");
 
     @Override
     public void execute(@NotNull ActionContext ctxt)
     {
         Vehicle vehicle = this.selectTarget(ctxt);
         // エンティティを取得し, もし存在しない場合は例外をスローする。
-        Entity entity = ctxt.input(IN_ENTITY).selectTarget(ctxt.getContext())
+        Entity entity = ctxt.input(IN_PASSENGER).selectTarget(ctxt.getContext())
                 .orElseThrow(() -> new IllegalActionInputException("エンティティが見つかりません。"));
 
         ctxt.output(OUT_ENTITY, entity);
         // エンティティを乗り物から降ろす。
-        vehicle.eject();
+        vehicle.removePassenger(entity);
     }
 
     @Override
@@ -74,7 +74,7 @@ public class VehicleExitAction extends AbstractVehicleAction
         Entity entity = e.getExited();
 
         // ↓ 乗り物自体の比較は, #checkMatchedVehicleEvent で行っているので, ここではエンティティの比較のみ行う。
-        boolean result = ctxt.ifHasInput(IN_ENTITY, inputEntity -> inputEntity.checkMatchedEntity(entity));
+        boolean result = ctxt.ifHasInput(IN_PASSENGER, inputEntity -> inputEntity.checkMatchedEntity(entity));
         if (result)
             this.makeOutputs(ctxt, e.getVehicle(), entity);
 
@@ -86,9 +86,9 @@ public class VehicleExitAction extends AbstractVehicleAction
     {
         Vehicle vehicle = this.selectTarget(ctxt);
         // entity を選択しないことも可能。
-        Entity entity = ctxt.input(IN_ENTITY).selectTarget(ctxt.getContext()).orElse(null);
-        if (ctxt.hasInput(IN_ENTITY) && entity == null)
-            throw new IllegalActionInputException(IN_ENTITY, "Unable to find the entity to board the vehicle.");
+        Entity entity = ctxt.input(IN_PASSENGER).selectTarget(ctxt.getContext()).orElse(null);
+        if (ctxt.hasInput(IN_PASSENGER) && entity == null)
+            throw new IllegalActionInputException(IN_PASSENGER, "Unable to find the entity to board the vehicle.");
 
         boolean result = !vehicle.getPassengers().contains(entity);
         if (result)
@@ -116,9 +116,9 @@ public class VehicleExitAction extends AbstractVehicleAction
     public InputBoard getInputBoard(ScenarioType type)
     {
         InputBoard board = super.getInputBoard(type)
-                .register(IN_ENTITY);
+                .register(IN_PASSENGER);
         if (type == ScenarioType.ACTION_EXECUTE)
-            board.requirePresent(IN_ENTITY);
+            board.requirePresent(IN_PASSENGER);
 
         return board;
     }

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleExitAction.java
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/java/org/kunlab/scenamatica/action/actions/base/entity/vehicle/VehicleExitAction.java
@@ -1,0 +1,110 @@
+package org.kunlab.scenamatica.action.actions.base.entity.vehicle;
+
+import org.bukkit.EntityEffect;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Vehicle;
+import org.bukkit.event.Event;
+import org.bukkit.event.vehicle.VehicleExitEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.kunlab.scenamatica.bookkeeper.annotations.ActionDoc;
+import org.kunlab.scenamatica.bookkeeper.annotations.OutputDoc;
+import org.kunlab.scenamatica.exceptions.scenario.IllegalActionInputException;
+import org.kunlab.scenamatica.interfaces.action.ActionContext;
+import org.kunlab.scenamatica.interfaces.action.input.InputToken;
+import org.kunlab.scenamatica.interfaces.action.types.Executable;
+import org.kunlab.scenamatica.interfaces.action.types.Expectable;
+import org.kunlab.scenamatica.interfaces.action.types.Requireable;
+import org.kunlab.scenamatica.interfaces.structures.specifiers.EntitySpecifier;
+
+import java.util.Collections;
+import java.util.List;
+
+@ActionDoc(
+        name = "乗り物からの後者",
+        description = "エンティティを乗り物から降ろします。",
+        events = {
+                VehicleExitEvent.class
+        },
+
+        executable = "エンティティを乗り物から降ろします。",
+        expectable = "エンティティが乗り物から降りることを期待します。",
+        requireable = ActionDoc.UNALLOWED,
+
+        outputs = {
+                @OutputDoc(
+                        name = VehicleExitAction.OUT_ENTITY,
+                        description = "降りたエンティティです。",
+                        type = EntityEffect.class
+                )
+        }
+)
+public class VehicleExitAction extends AbstractVehicleAction
+        implements Executable, Expectable, Requireable
+{
+    public static final String OUT_ENTITY = "passenger";
+
+    public static final InputToken<EntitySpecifier<Entity>> IN_ENTITY = ofSpecifier("entity");
+
+    @Override
+    public void execute(@NotNull ActionContext ctxt)
+    {
+        Vehicle vehicle = this.selectTarget(ctxt);
+        // エンティティを取得し, もし存在しない場合は例外をスローする。
+        Entity entity = ctxt.input(IN_ENTITY).selectTarget(ctxt.getContext())
+                .orElseThrow(() -> new IllegalActionInputException("エンティティが見つかりません。"));
+
+        ctxt.output(OUT_ENTITY, entity);
+        // エンティティを乗り物から降ろす。
+        vehicle.eject();
+    }
+
+    @Override
+    public boolean checkFired(@NotNull ActionContext ctxt, @NotNull Event event)
+    {
+        if (!super.checkMatchedVehicleEvent(ctxt, event))
+            return false;
+        assert event instanceof VehicleExitEvent;
+        VehicleExitEvent e = (VehicleExitEvent) event;
+
+        Entity entity = e.getExited();
+
+        // ↓ 乗り物自体の比較は, #checkMatchedVehicleEvent で行っているので, ここではエンティティの比較のみ行う。
+        boolean result = ctxt.ifHasInput(IN_ENTITY, inputEntity -> inputEntity.checkMatchedEntity(entity));
+        if (result)
+            this.makeOutputs(ctxt, e.getVehicle(), entity);
+
+        return result;
+    }
+
+    @Override
+    public boolean checkConditionFulfilled(@NotNull ActionContext ctxt)
+    {
+        Vehicle vehicle = this.selectTarget(ctxt);
+        // entity を選択しないことも可能。
+        Entity entity = ctxt.input(IN_ENTITY).selectTarget(ctxt.getContext()).orElse(null);
+        if (ctxt.hasInput(IN_ENTITY) && entity == null)
+            throw new IllegalActionInputException(IN_ENTITY, "Unable to find the entity to board the vehicle.");
+
+        boolean result = !vehicle.getPassengers().contains(entity);
+        if (result)
+            this.makeOutputs(ctxt, vehicle, entity);
+
+        return result;
+    }
+
+    private void makeOutputs(@NotNull ActionContext ctxt, @NotNull Vehicle vehicle, @Nullable Entity entity)
+    {
+        if (entity != null)
+            ctxt.output(OUT_ENTITY, entity);
+        super.makeOutputs(ctxt, vehicle);
+    }
+
+    @Override
+    public List<Class<? extends Event>> getAttachingEvents()
+    {
+        return Collections.singletonList(
+                VehicleExitEvent.class
+        );
+    }
+}

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Create-2.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Create-2.yml
@@ -8,8 +8,6 @@ on:
   - type: manual_dispatch
 
 context:
-  actors:
-    - name: Actor01
   entities:
     - type: boat
       location:

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Create-2.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Create-2.yml
@@ -1,8 +1,8 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_entity_vehicle_exit_2
-description: Testing entity_vehicle_exit action without entity works or not
+name: actions_entity_vehicle_create_2
+description: Testing entity_vehicle_create action  without arguments works or not
 on:
   - type: on_load
   - type: manual_dispatch
@@ -21,9 +21,8 @@ context:
 
 scenario:
   - type: execute
-    action: entity_vehicle_exit
+    action: entity_vehicle_create
     with:
-      passenger: Actor01
       target:
         type: boat
         location:
@@ -31,10 +30,4 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: entity_vehicle_exit
-    with:
-      passenger: Actor01
-  - type: require
-    action: entity_vehicle_exit
-    with:
-      passenger: Actor01
+    action: entity_vehicle_create

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Create-2.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Create-2.yml
@@ -1,8 +1,8 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_entity_vehicle_create_2
-description: Testing entity_vehicle_create action  without arguments works or not
+name: actions_vehicle_create_2
+description: Testing vehicle_create action  without arguments works or not
 on:
   - type: on_load
   - type: manual_dispatch
@@ -21,7 +21,7 @@ context:
 
 scenario:
   - type: execute
-    action: entity_vehicle_create
+    action: vehicle_create
     with:
       target:
         type: boat
@@ -30,4 +30,4 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: entity_vehicle_create
+    action: vehicle_create

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Create.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Create.yml
@@ -1,8 +1,8 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_entity_vehicle_exit_2
-description: Testing entity_vehicle_exit action without entity works or not
+name: actions_entity_vehicle_create
+description: Testing entity_vehicle_create action works or not
 on:
   - type: on_load
   - type: manual_dispatch
@@ -21,9 +21,8 @@ context:
 
 scenario:
   - type: execute
-    action: entity_vehicle_exit
+    action: entity_vehicle_create
     with:
-      passenger: Actor01
       target:
         type: boat
         location:
@@ -31,10 +30,11 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: entity_vehicle_exit
+    action: entity_vehicle_create
     with:
-      passenger: Actor01
-  - type: require
-    action: entity_vehicle_exit
-    with:
-      passenger: Actor01
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Create.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Create.yml
@@ -1,8 +1,8 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_entity_vehicle_create
-description: Testing entity_vehicle_create action works or not
+name: actions_vehicle_create
+description: Testing vehicle_create action works or not
 on:
   - type: on_load
   - type: manual_dispatch
@@ -21,7 +21,7 @@ context:
 
 scenario:
   - type: execute
-    action: entity_vehicle_create
+    action: vehicle_create
     with:
       target:
         type: boat
@@ -30,7 +30,7 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: entity_vehicle_create
+    action: vehicle_create
     with:
       target:
         type: boat

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Damage-2.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Damage-2.yml
@@ -1,0 +1,38 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_vehicle_damage_2
+description: Testing vehicle_damage without damage value action works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  actors:
+    - name: Actor01
+  entities:
+    - type: boat
+      location:
+        x: 0
+        y: 5
+        z: 0
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: vehicle_damage
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+      attacker: Actor01
+      amount: 1.0
+  - type: expect
+    action: vehicle_damage
+    with:
+      attacker: Actor01
+      amount: 1.0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Damage-3.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Damage-3.yml
@@ -1,0 +1,43 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_vehicle_damage_3
+description: Testing vehicle_damage without attacker action works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  actors:
+    - name: Actor01
+  entities:
+    - type: boat
+      location:
+        x: 0
+        y: 5
+        z: 0
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: vehicle_damage
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+      attacker: Actor01
+      amount: 1.0
+  - type: expect
+    action: vehicle_damage
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+      amount: 1.0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Damage-4.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Damage-4.yml
@@ -1,0 +1,36 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_vehicle_damage_4
+description: Testing vehicle_damage without arguments action works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  actors:
+    - name: Actor01
+  entities:
+    - type: boat
+      location:
+        x: 0
+        y: 5
+        z: 0
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: vehicle_damage
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+      attacker: Actor01
+      amount: 1.0
+  - type: expect
+    action: vehicle_damage
+    with:

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Damage-5.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Damage-5.yml
@@ -1,0 +1,53 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_vehicle_damage_5
+description: Testing vehicle_damage if destroys the vehicle when 41 is specified as its damage action works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  actors:
+    - name: Actor01
+  entities:
+    - type: boat
+      location:
+        x: 0
+        y: 5
+        z: 0
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: vehicle_damage
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+      attacker: Actor01
+      amount: 41.0
+  - type: expect
+    action: vehicle_damage
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+      attacker: Actor01
+      amount: 41.0
+  - type: require
+    action: vehicle_destroy
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Damage.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Damage.yml
@@ -1,0 +1,44 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_vehicle_damage
+description: Testing vehicle_damage action works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  actors:
+    - name: Actor01
+  entities:
+    - type: boat
+      location:
+        x: 0
+        y: 5
+        z: 0
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: vehicle_damage
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+      attacker: Actor01
+      amount: 1.0
+  - type: expect
+    action: vehicle_damage
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+      attacker: Actor01
+      amount: 1.0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Destroy-2.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Destroy-2.yml
@@ -1,13 +1,15 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_vehicle_create
-description: Testing vehicle_create action works or not
+name: actions_vehicle_destroy_2
+description: Testing vehicle_destroy action without attacker works or not
 on:
   - type: on_load
   - type: manual_dispatch
 
 context:
+  actors:
+    - name: Actor01
   entities:
     - type: boat
       location:
@@ -19,7 +21,7 @@ context:
 
 scenario:
   - type: execute
-    action: vehicle_create
+    action: vehicle_destroy
     with:
       target:
         type: boat
@@ -28,7 +30,16 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: vehicle_create
+    action: vehicle_destroy
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+  - type: require
+    action: vehicle_destroy
     with:
       target:
         type: boat

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Destroy-3.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Destroy-3.yml
@@ -1,13 +1,15 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_vehicle_create
-description: Testing vehicle_create action works or not
+name: actions_vehicle_destroy_3
+description: Testing vehicle_destroy action without arguments works or not
 on:
   - type: on_load
   - type: manual_dispatch
 
 context:
+  actors:
+    - name: Actor01
   entities:
     - type: boat
       location:
@@ -19,7 +21,7 @@ context:
 
 scenario:
   - type: execute
-    action: vehicle_create
+    action: vehicle_destroy
     with:
       target:
         type: boat
@@ -28,11 +30,4 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: vehicle_create
-    with:
-      target:
-        type: boat
-        location:
-          x: 0
-          y: 5
-          z: 0
+    action: vehicle_destroy

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Destroy.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Destroy.yml
@@ -1,13 +1,15 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_vehicle_create
-description: Testing vehicle_create action works or not
+name: actions_vehicle_destroy
+description: Testing vehicle_destroy action works or not
 on:
   - type: on_load
   - type: manual_dispatch
 
 context:
+  actors:
+    - name: Actor01
   entities:
     - type: boat
       location:
@@ -19,7 +21,7 @@ context:
 
 scenario:
   - type: execute
-    action: vehicle_create
+    action: vehicle_destroy
     with:
       target:
         type: boat
@@ -27,8 +29,19 @@ scenario:
           x: 0
           y: 5
           z: 0
+      attacker: Actor01
   - type: expect
-    action: vehicle_create
+    action: vehicle_destroy
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+      attacker: Actor01
+  - type: require
+    action: vehicle_destroy
     with:
       target:
         type: boat

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter-2.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter-2.yml
@@ -1,0 +1,40 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_entity_vehicle_enter_2
+description: Testing entity_vehicle_enter action without entity works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  actors:
+    - name: Actor01
+  entities:
+    - type: boat
+      location:
+        x: 0
+        y: 5
+        z: 0
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: entity_vehicle_enter
+    with:
+      passenger: Actor01
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+  - type: expect
+    action: entity_vehicle_enter
+    with:
+      passenger: Actor01
+  - type: require
+    action: entity_vehicle_enter
+    with:
+      passenger: Actor01

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter-2.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter-2.yml
@@ -1,8 +1,8 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_entity_vehicle_enter_2
-description: Testing entity_vehicle_enter action without entity works or not
+name: actions_vehicle_enter_2
+description: Testing vehicle_enter action without entity works or not
 on:
   - type: on_load
   - type: manual_dispatch
@@ -21,7 +21,7 @@ context:
 
 scenario:
   - type: execute
-    action: entity_vehicle_enter
+    action: vehicle_enter
     with:
       passenger: Actor01
       target:
@@ -31,10 +31,10 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: entity_vehicle_enter
+    action: vehicle_enter
     with:
       passenger: Actor01
   - type: require
-    action: entity_vehicle_enter
+    action: vehicle_enter
     with:
       passenger: Actor01

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter-3.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter-3.yml
@@ -1,0 +1,50 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_entity_vehicle_enter_3
+description: Testing entity_vehicle_enter action without passenger works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  actors:
+    - name: Actor01
+  entities:
+    - type: boat
+      location:
+        x: 0
+        y: 5
+        z: 0
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: entity_vehicle_enter
+    with:
+      passenger: Actor01
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+  - type: expect
+    action: entity_vehicle_enter
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+  - type: require
+    action: entity_vehicle_enter
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter-3.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter-3.yml
@@ -1,8 +1,8 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_entity_vehicle_enter_3
-description: Testing entity_vehicle_enter action without passenger works or not
+name: actions_vehicle_enter_3
+description: Testing vehicle_enter action without passenger works or not
 on:
   - type: on_load
   - type: manual_dispatch
@@ -21,7 +21,7 @@ context:
 
 scenario:
   - type: execute
-    action: entity_vehicle_enter
+    action: vehicle_enter
     with:
       passenger: Actor01
       target:
@@ -31,7 +31,7 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: entity_vehicle_enter
+    action: vehicle_enter
     with:
       target:
         type: boat
@@ -40,7 +40,7 @@ scenario:
           y: 5
           z: 0
   - type: require
-    action: entity_vehicle_enter
+    action: vehicle_enter
     with:
       target:
         type: boat

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter-4.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter-4.yml
@@ -1,8 +1,8 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_entity_vehicle_enter_4
-description: Testing entity_vehicle_enter action without arguments works or not
+name: actions_vehicle_enter_4
+description: Testing vehicle_enter action without arguments works or not
 on:
   - type: on_load
   - type: manual_dispatch
@@ -21,7 +21,7 @@ context:
 
 scenario:
   - type: execute
-    action: entity_vehicle_enter
+    action: vehicle_enter
     with:
       passenger: Actor01
       target:
@@ -31,9 +31,9 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: entity_vehicle_enter
+    action: vehicle_enter
   - type: require
-    action: entity_vehicle_enter
+    action: vehicle_enter
     with:
       target:
         type: boat

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter-4.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter-4.yml
@@ -1,0 +1,43 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_entity_vehicle_enter_4
+description: Testing entity_vehicle_enter action without arguments works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  actors:
+    - name: Actor01
+  entities:
+    - type: boat
+      location:
+        x: 0
+        y: 5
+        z: 0
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: entity_vehicle_enter
+    with:
+      passenger: Actor01
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+  - type: expect
+    action: entity_vehicle_enter
+  - type: require
+    action: entity_vehicle_enter
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter.yml
@@ -1,8 +1,8 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_entity_vehicle_enter
-description: Testing entity_vehicle_enter action works or not
+name: actions_vehicle_enter
+description: Testing vehicle_enter action works or not
 on:
   - type: on_load
   - type: manual_dispatch
@@ -21,7 +21,7 @@ context:
 
 scenario:
   - type: execute
-    action: entity_vehicle_enter
+    action: vehicle_enter
     with:
       passenger: Actor01
       target:
@@ -31,7 +31,7 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: entity_vehicle_enter
+    action: vehicle_enter
     with:
       passenger: Actor01
       target:
@@ -41,7 +41,7 @@ scenario:
           y: 5
           z: 0
   - type: require
-    action: entity_vehicle_enter
+    action: vehicle_enter
     with:
       passenger: Actor01
       target:

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Enter.yml
@@ -1,0 +1,52 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_entity_vehicle_enter
+description: Testing entity_vehicle_enter action works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  actors:
+    - name: Actor01
+  entities:
+    - type: boat
+      location:
+        x: 0
+        y: 5
+        z: 0
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: entity_vehicle_enter
+    with:
+      passenger: Actor01
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+  - type: expect
+    action: entity_vehicle_enter
+    with:
+      passenger: Actor01
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+  - type: require
+    action: entity_vehicle_enter
+    with:
+      passenger: Actor01
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-2.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-2.yml
@@ -5,7 +5,29 @@ name: actions_vehicle_exit_2
 description: Testing vehicle_exit action without entity works or not
 on:
   - type: on_load
+    before:
+      - type: execute
+        action: vehicle_enter
+        with:
+          passenger: Actor01
+          target:
+            type: boat
+            location:
+              x: 0
+              y: 5
+              z: 0
   - type: manual_dispatch
+    before:
+      - type: execute
+        action: vehicle_enter
+        with:
+          passenger: Actor01
+          target:
+            type: boat
+            location:
+              x: 0
+              y: 5
+              z: 0
 
 context:
   actors:

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-2.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-2.yml
@@ -1,8 +1,8 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_entity_vehicle_exit_2
-description: Testing entity_vehicle_exit action without entity works or not
+name: actions_vehicle_exit_2
+description: Testing vehicle_exit action without entity works or not
 on:
   - type: on_load
   - type: manual_dispatch
@@ -21,7 +21,7 @@ context:
 
 scenario:
   - type: execute
-    action: entity_vehicle_exit
+    action: vehicle_exit
     with:
       passenger: Actor01
       target:
@@ -31,10 +31,10 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: entity_vehicle_exit
+    action: vehicle_exit
     with:
       passenger: Actor01
   - type: require
-    action: entity_vehicle_exit
+    action: vehicle_exit
     with:
       passenger: Actor01

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-3.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-3.yml
@@ -1,8 +1,8 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_entity_vehicle_exit_3
-description: Testing entity_vehicle_exit action without passenger works or not
+name: actions_vehicle_exit_3
+description: Testing vehicle_exit action without passenger works or not
 on:
   - type: on_load
   - type: manual_dispatch
@@ -21,7 +21,7 @@ context:
 
 scenario:
   - type: execute
-    action: entity_vehicle_exit
+    action: vehicle_exit
     with:
       passenger: Actor01
       target:
@@ -31,7 +31,7 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: entity_vehicle_exit
+    action: vehicle_exit
     with:
       target:
         type: boat
@@ -40,7 +40,7 @@ scenario:
           y: 5
           z: 0
   - type: require
-    action: entity_vehicle_exit
+    action: vehicle_exit
     with:
       target:
         type: boat

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-3.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-3.yml
@@ -1,0 +1,50 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_entity_vehicle_exit_3
+description: Testing entity_vehicle_exit action without passenger works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  actors:
+    - name: Actor01
+  entities:
+    - type: boat
+      location:
+        x: 0
+        y: 5
+        z: 0
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: entity_vehicle_exit
+    with:
+      passenger: Actor01
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+  - type: expect
+    action: entity_vehicle_exit
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+  - type: require
+    action: entity_vehicle_exit
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-3.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-3.yml
@@ -5,7 +5,29 @@ name: actions_vehicle_exit_3
 description: Testing vehicle_exit action without passenger works or not
 on:
   - type: on_load
+    before:
+      - type: execute
+        action: vehicle_enter
+        with:
+          passenger: Actor01
+          target:
+            type: boat
+            location:
+              x: 0
+              y: 5
+              z: 0
   - type: manual_dispatch
+    before:
+      - type: execute
+        action: vehicle_enter
+        with:
+          passenger: Actor01
+          target:
+            type: boat
+            location:
+              x: 0
+              y: 5
+              z: 0
 
 context:
   actors:

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-4.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-4.yml
@@ -1,0 +1,43 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_entity_vehicle_exit_4
+description: Testing entity_vehicle_exit action without arguments works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  actors:
+    - name: Actor01
+  entities:
+    - type: boat
+      location:
+        x: 0
+        y: 5
+        z: 0
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: entity_vehicle_exit
+    with:
+      passenger: Actor01
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+  - type: expect
+    action: entity_vehicle_exit
+  - type: require
+    action: entity_vehicle_exit
+    with:
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-4.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-4.yml
@@ -1,8 +1,8 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_entity_vehicle_exit_4
-description: Testing entity_vehicle_exit action without arguments works or not
+name: actions_vehicle_exit_4
+description: Testing vehicle_exit action without arguments works or not
 on:
   - type: on_load
   - type: manual_dispatch
@@ -21,7 +21,7 @@ context:
 
 scenario:
   - type: execute
-    action: entity_vehicle_exit
+    action: vehicle_exit
     with:
       passenger: Actor01
       target:
@@ -31,9 +31,9 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: entity_vehicle_exit
+    action: vehicle_exit
   - type: require
-    action: entity_vehicle_exit
+    action: vehicle_exit
     with:
       target:
         type: boat

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-4.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit-4.yml
@@ -5,7 +5,29 @@ name: actions_vehicle_exit_4
 description: Testing vehicle_exit action without arguments works or not
 on:
   - type: on_load
+    before:
+      - type: execute
+        action: vehicle_enter
+        with:
+          passenger: Actor01
+          target:
+            type: boat
+            location:
+              x: 0
+              y: 5
+              z: 0
   - type: manual_dispatch
+    before:
+      - type: execute
+        action: vehicle_enter
+        with:
+          passenger: Actor01
+          target:
+            type: boat
+            location:
+              x: 0
+              y: 5
+              z: 0
 
 context:
   actors:

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit.yml
@@ -1,8 +1,8 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_entity_vehicle_exit
-description: Testing entity_vehicle_exit action works or not
+name: actions_vehicle_exit
+description: Testing vehicle_exit action works or not
 on:
   - type: on_load
   - type: manual_dispatch
@@ -21,7 +21,7 @@ context:
 
 scenario:
   - type: execute
-    action: entity_vehicle_exit
+    action: vehicle_exit
     with:
       passenger: Actor01
       target:
@@ -31,11 +31,11 @@ scenario:
           y: 5
           z: 0
   - type: expect
-    action: entity_vehicle_exit
+    action: vehicle_exit
     with:
       passenger: Actor01
   - type: require
-    action: entity_vehicle_exit
+    action: vehicle_exit
     with:
       passenger: Actor01
       target:

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit.yml
@@ -5,7 +5,29 @@ name: actions_vehicle_exit
 description: Testing vehicle_exit action works or not
 on:
   - type: on_load
+    before:
+      - type: execute
+        action: vehicle_enter
+        with:
+          passenger: Actor01
+          target:
+            type: boat
+            location:
+              x: 0
+              y: 5
+              z: 0
   - type: manual_dispatch
+    before:
+      - type: execute
+        action: vehicle_enter
+        with:
+          passenger: Actor01
+          target:
+            type: boat
+            location:
+              x: 0
+              y: 5
+              z: 0
 
 context:
   actors:

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit.yml
@@ -1,8 +1,8 @@
 # noinspection YAMLSchemaValidation
 scenamatica: ${project.version}
 
-name: actions_entity_vehicle_exit_2
-description: Testing entity_vehicle_exit action without entity works or not
+name: actions_entity_vehicle_exit
+description: Testing entity_vehicle_exit action works or not
 on:
   - type: on_load
   - type: manual_dispatch
@@ -38,3 +38,9 @@ scenario:
     action: entity_vehicle_exit
     with:
       passenger: Actor01
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0

--- a/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit.yml
+++ b/Scenamatica/ScenamaticaActions/Base_v1_13_2/src/main/resources/scenarios/actions/entity/vehicle/Exit.yml
@@ -1,0 +1,40 @@
+# noinspection YAMLSchemaValidation
+scenamatica: ${project.version}
+
+name: actions_entity_vehicle_exit_2
+description: Testing entity_vehicle_exit action without entity works or not
+on:
+  - type: on_load
+  - type: manual_dispatch
+
+context:
+  actors:
+    - name: Actor01
+  entities:
+    - type: boat
+      location:
+        x: 0
+        y: 5
+        z: 0
+  stage:
+    type: FLAT
+
+scenario:
+  - type: execute
+    action: entity_vehicle_exit
+    with:
+      passenger: Actor01
+      target:
+        type: boat
+        location:
+          x: 0
+          y: 5
+          z: 0
+  - type: expect
+    action: entity_vehicle_exit
+    with:
+      passenger: Actor01
+  - type: require
+    action: entity_vehicle_exit
+    with:
+      passenger: Actor01

--- a/Scenamatica/ScenamaticaModels/src/main/java/org/kunlab/scenamatica/interfaces/structures/minecraft/entity/entities/VehicleStructure.java
+++ b/Scenamatica/ScenamaticaModels/src/main/java/org/kunlab/scenamatica/interfaces/structures/minecraft/entity/entities/VehicleStructure.java
@@ -1,0 +1,15 @@
+package org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities;
+
+import org.bukkit.entity.Vehicle;
+import org.kunlab.scenamatica.bookkeeper.annotations.TypeDoc;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.EntityStructure;
+
+@TypeDoc(
+        name = "Vehicle",
+        description = "乗り物エンティティの情報を格納します。",
+        mappingOf = Vehicle.class
+)
+public interface VehicleStructure extends EntityStructure
+{
+
+}

--- a/Scenamatica/ScenamaticaPlugin/src/main/resources/config.yml
+++ b/Scenamatica/ScenamaticaPlugin/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 # @project      Scenamatica ${project.version}
 # @author       Peyang <https://peya.tokyo>
-# @license      The MIT License (MIT) <https://opensource.org/licenses/MIT>
+# @license      The MIT Licence (MIT) <https://opensource.org/licenses/MIT>
 
 # ------------[ インターフェース設定 ]------------
 # Scenamatica のインターフェースの設定を定義します。

--- a/Scenamatica/ScenamaticaScenarioFile/src/main/java/org/kunlab/scenamatica/scenariofile/SelectiveEntityStructureSerializer.java
+++ b/Scenamatica/ScenamaticaScenarioFile/src/main/java/org/kunlab/scenamatica/scenariofile/SelectiveEntityStructureSerializer.java
@@ -3,6 +3,7 @@ package org.kunlab.scenamatica.scenariofile;
 import lombok.SneakyThrows;
 import lombok.Value;
 import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Boat;
 import org.bukkit.entity.DragonFireball;
 import org.bukkit.entity.Egg;
 import org.bukkit.entity.EnderPearl;
@@ -12,6 +13,7 @@ import org.bukkit.entity.Fireball;
 import org.bukkit.entity.FishHook;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LlamaSpit;
+import org.bukkit.entity.Minecart;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.ShulkerBullet;
@@ -21,6 +23,7 @@ import org.bukkit.entity.SpectralArrow;
 import org.bukkit.entity.SplashPotion;
 import org.bukkit.entity.ThrownExpBottle;
 import org.bukkit.entity.Trident;
+import org.bukkit.entity.Vehicle;
 import org.bukkit.entity.WitherSkull;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -32,10 +35,12 @@ import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.EntityStruc
 import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.PlayerStructure;
 import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities.EntityItemStructure;
 import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities.ProjectileStructure;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities.VehicleStructure;
 import org.kunlab.scenamatica.structures.minecraft.entity.EntityStructureImpl;
 import org.kunlab.scenamatica.structures.minecraft.entity.PlayerStructureImpl;
 import org.kunlab.scenamatica.structures.minecraft.entity.entities.EntityItemStructureImpl;
 import org.kunlab.scenamatica.structures.minecraft.entity.entities.ProjectileStructureImpl;
+import org.kunlab.scenamatica.structures.minecraft.entity.entities.VehicleStructureImpl;
 
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -103,6 +108,7 @@ public class SelectiveEntityStructureSerializer
                 (entity, ignored) -> EntityStructureImpl.of(entity)
         );
 
+        registerVehicles();
         registerProjectiles();
     }
 
@@ -139,6 +145,34 @@ public class SelectiveEntityStructureSerializer
                     projectileEntry.getKey(),
                     ProjectileStructure.class,
                     Projectile.class,
+                    serializer,
+                    deserializer,
+                    validator,
+                    constructor
+            );
+        }
+    }
+
+    @SneakyThrows
+    private static void registerVehicles()
+    {
+        BiFunction<VehicleStructure, StructureSerializer, Map<String, Object>> serializer = VehicleStructureImpl::serialize;
+        StructureSerializerImpl.ThrowableBiFunction<StructuredYamlNode, StructureSerializer, VehicleStructure> deserializer = VehicleStructureImpl::deserialize;
+        StructureSerializerImpl.ThrowableBiConsumer<StructuredYamlNode, StructureSerializer> validator = VehicleStructureImpl::validate;
+        BiFunction<Vehicle, StructureSerializer, VehicleStructure> constructor = VehicleStructureImpl::of;
+
+        Map<EntityType, Class<? extends Vehicle>> vehicleTypes = new HashMap<EntityType, Class<? extends Vehicle>>()
+        {{
+            this.put(EntityType.BOAT, Boat.class);
+            this.put(EntityType.MINECART, Minecart.class);
+        }};
+
+        for (Map.Entry<EntityType, Class<? extends Vehicle>> vehicleEntry : vehicleTypes.entrySet())
+        {
+            registerStructure(
+                    vehicleEntry.getKey(),
+                    VehicleStructure.class,
+                    Vehicle.class,
                     serializer,
                     deserializer,
                     validator,

--- a/Scenamatica/ScenamaticaSelectorEngine/src/main/java/org/kunlab/scenamatica/selector/predicates/NamePredicate.java
+++ b/Scenamatica/ScenamaticaSelectorEngine/src/main/java/org/kunlab/scenamatica/selector/predicates/NamePredicate.java
@@ -13,12 +13,10 @@ public class NamePredicate extends AbstractGeneralEntitySelectorPredicate
     @Override
     public boolean test(Player basis, Entity entity, Map<? super String, Object> properties)
     {
-        String nameDef = (String) properties.get(KEY_NAME);
-        if (nameDef == null)
-            return true;
-
         String name = entity.getName();
         AmbiguousString ambiguousString = (AmbiguousString) properties.get(KEY_NAME);
+        if (ambiguousString == null)
+            return true;
 
         return ambiguousString.test(name);
     }

--- a/Scenamatica/ScenamaticaStructures/src/main/java/org/kunlab/scenamatica/structures/minecraft/entity/entities/VehicleStructureImpl.java
+++ b/Scenamatica/ScenamaticaStructures/src/main/java/org/kunlab/scenamatica/structures/minecraft/entity/entities/VehicleStructureImpl.java
@@ -1,6 +1,7 @@
 package org.kunlab.scenamatica.structures.minecraft.entity.entities;
 
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Vehicle;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,19 +36,24 @@ public class VehicleStructureImpl extends EntityStructureImpl implements Vehicle
     }
 
     @NotNull
-    public static Map<String, Object> serializeVehicle(@NotNull VehicleStructure structure, @NotNull StructureSerializer serializer)
+    public static Map<String, Object> serialize(@NotNull VehicleStructure structure, @NotNull StructureSerializer serializer)
     {
         return EntityStructureImpl.serialize(structure, serializer);
     }
 
-    public static void validateVehicle(@NotNull StructuredYamlNode node, @NotNull StructureSerializer serializer) throws YamlParsingException
+    public static void validate(@NotNull StructuredYamlNode node, @NotNull StructureSerializer serializer) throws YamlParsingException
     {
         EntityStructureImpl.validate(node);
     }
 
     @NotNull
-    public static EntityStructureImpl deserializeVehicle(@NotNull StructuredYamlNode node, @NotNull StructureSerializer serializer) throws YamlParsingException
+    public static VehicleStructureImpl deserialize(@NotNull StructuredYamlNode node, @NotNull StructureSerializer serializer) throws YamlParsingException
     {
         return new VehicleStructureImpl(EntityStructureImpl.deserialize(node, serializer));
+    }
+
+    public static VehicleStructure of(@NotNull Vehicle vehicle, @NotNull StructureSerializer serializer)
+    {
+        return new VehicleStructureImpl(EntityStructureImpl.of(vehicle));
     }
 }

--- a/Scenamatica/ScenamaticaStructures/src/main/java/org/kunlab/scenamatica/structures/minecraft/entity/entities/VehicleStructureImpl.java
+++ b/Scenamatica/ScenamaticaStructures/src/main/java/org/kunlab/scenamatica/structures/minecraft/entity/entities/VehicleStructureImpl.java
@@ -1,0 +1,53 @@
+package org.kunlab.scenamatica.structures.minecraft.entity.entities;
+
+import org.bukkit.entity.EntityType;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.kunlab.scenamatica.exceptions.scenariofile.YamlParsingException;
+import org.kunlab.scenamatica.interfaces.scenariofile.StructureSerializer;
+import org.kunlab.scenamatica.interfaces.scenariofile.StructuredYamlNode;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.DamageStructure;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.EntityStructure;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.entity.entities.VehicleStructure;
+import org.kunlab.scenamatica.interfaces.structures.minecraft.misc.LocationStructure;
+import org.kunlab.scenamatica.structures.minecraft.entity.EntityStructureImpl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class VehicleStructureImpl extends EntityStructureImpl implements VehicleStructure
+{
+    public VehicleStructureImpl(EntityType type, LocationStructure location, Vector velocity, String customName, UUID uuid, Boolean glowing, Boolean gravity, Boolean silent, Boolean customNameVisible, Boolean invulnerable, @NotNull List<String> tags, Integer maxHealth, Integer health, DamageStructure lastDamageCause, Integer fireTicks, Integer ticksLived, Integer portalCooldown, Boolean persistent, Float fallDistance)
+    {
+        super(type, location, velocity, customName, uuid, glowing, gravity, silent, customNameVisible, invulnerable, tags, maxHealth, health, lastDamageCause, fireTicks, ticksLived, portalCooldown, persistent, fallDistance);
+    }
+
+    public VehicleStructureImpl(@NotNull EntityStructure original)
+    {
+        super(original);
+    }
+
+    public VehicleStructureImpl(@Nullable EntityType type, @NotNull EntityStructure original)
+    {
+        super(type, original);
+    }
+
+    @NotNull
+    public static Map<String, Object> serializeVehicle(@NotNull VehicleStructure structure, @NotNull StructureSerializer serializer)
+    {
+        return EntityStructureImpl.serialize(structure, serializer);
+    }
+
+    public static void validateVehicle(@NotNull StructuredYamlNode node, @NotNull StructureSerializer serializer) throws YamlParsingException
+    {
+        EntityStructureImpl.validate(node);
+    }
+
+    @NotNull
+    public static EntityStructureImpl deserializeVehicle(@NotNull StructuredYamlNode node, @NotNull StructureSerializer serializer) throws YamlParsingException
+    {
+        return new VehicleStructureImpl(EntityStructureImpl.deserialize(node, serializer));
+    }
+}

--- a/Scenamatica/ScenamaticaStructures/src/main/java/org/kunlab/scenamatica/structures/specifiers/EntitySpecifierImpl.java
+++ b/Scenamatica/ScenamaticaStructures/src/main/java/org/kunlab/scenamatica/structures/specifiers/EntitySpecifierImpl.java
@@ -89,7 +89,14 @@ public class EntitySpecifierImpl<E extends Entity> implements EntitySpecifier<E>
             UUID mayUUID = tryConvertToUUID(str);
 
             if (mayUUID == null)
-                return new EntitySpecifierImpl<>(Selector.compile(str));
+            {
+                Optional<Selector> selector = Selector.tryCompile(str);
+                //noinspection OptionalIsPresent
+                if (selector.isPresent())
+                    return new EntitySpecifierImpl<>(selector.get());
+                else
+                    return new EntitySpecifierImpl<>(Selector.compile("[name=" + str + "]"));
+            }
             else
                 return new EntitySpecifierImpl<>(mayUUID);
         }


### PR DESCRIPTION
# feat(actions): Typical vehicle actions

## + Action: EX/EP `vehicle_create`

Creates a vehicle.

+ Category: `entity`
+ Attaching events:
  - [`VehicleCreateEvent`](https://jd.papermc.io/paper/1.13.2/org/bukkit/event/vehicle/VehicleCreateEvent.html)

### Differences via versions

#### 1.13.2: Base implemention

## + Action: EX/EP `vehicle_damage`

Hurts a vehicle.

+ Category: `entity`
+ Attaching events:
  - [`VehicleDamageEvent`](https://jd.papermc.io/paper/1.13.2/org/bukkit/event/vehicle/VehicleDamageEvent.html)

### Differences via versions

#### 1.13.2: Base implemention

## + Action: EX/EP/RQ `vehicle_destroy`

Hurts a vehicle.

+ Category: `entity`
+ Attaching events:
  - [`VehicleDestroyEvent`](https://jd.papermc.io/paper/1.13.2/org/bukkit/event/vehicle/VehicleDestroyEvent.html)

### Differences via versions

#### 1.13.2: Base implemention

## + Action: EX/EP/RQ `vehicle_enter`

Hurts a vehicle.

+ Category: `entity`
+ Attaching events:
  - [`VehicleEnterEvent`](https://jd.papermc.io/paper/1.13.2/org/bukkit/event/vehicle/VehicleEnterEvent.html)

### Differences via versions

#### 1.13.2: Base implemention

## + Action: EX/EP `vehicle_exit`

Hurts a vehicle.

+ Category: `entity`
+ Attaching events:
  - [`VehicleExitEvent`](https://jd.papermc.io/paper/1.13.2/org/bukkit/event/vehicle/VehicleExitEvent.html)

### Differences via versions

#### 1.13.2: Base implemention
